### PR TITLE
Fixed no-measure program in reset that was unsupported. + minor changes

### DIFF
--- a/examples/readout_fidelity.ipynb
+++ b/examples/readout_fidelity.ipynb
@@ -123,6 +123,138 @@
    "source": [
     "run_readouts(qc=get_qc('9q-square-noisy-qvm'))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using forest_benchmarking.readout.py"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Forest-benchmarking also provides a readout module with convenience functions for estimating readout and reset confusion matrices for groups of qubits. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from forest_benchmarking.readout import (estimate_joint_confusion_in_set, \n",
+    "                                        estimate_joint_reset_confusion, \n",
+    "                                        marginalize_confusion_matrix)\n",
+    "qc = get_qc('9q-square-noisy-qvm')\n",
+    "qubits = qc.qubits()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convenient estimation of (possibly joint) confusion matrices for groups of qubits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get all single qubit confusion matrices\n",
+    "one_q_ro_conf_matxs = estimate_joint_confusion_in_set(qc, use_active_reset=True)\n",
+    "\n",
+    "# get all pairwise confusion matrices from subset of qubits.\n",
+    "subset = qubits[:4]  # only look at 4 qubits of interest, this will mean (4 choose 2) = 6 matrices\n",
+    "two_q_ro_conf_matxs = estimate_joint_confusion_in_set(qc, qubits=subset, joint_group_size=2, use_active_reset=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## extract the 1q ro fidelities "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for qubit in qubits:\n",
+    "    conf_mat = one_q_ro_conf_matxs[(qubit,)]\n",
+    "    ro_fidelity = np.trace(conf_mat)/2 # average P(0 | 0) and P(1 | 1)\n",
+    "    print(f'q{qubit:<3d}{ro_fidelity:10f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick a 2q joint confusion matrix and compare marginal to 1q"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Comparing a joint n-qubit matrix to the estimated <n-qubit matrices can help reveal correlated errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "two_q_conf_mat = two_q_ro_conf_matxs[(subset[0],subset[-1])]\n",
+    "print(two_q_conf_mat)\n",
+    "print()\n",
+    "marginal = marginalize_confusion_matrix(two_q_conf_mat, [subset[0], subset[-1]], [subset[0]])\n",
+    "print(marginal)\n",
+    "print(one_q_ro_conf_matxs[(subset[0],)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Estimate confusion matrix for active reset error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "subset = tuple(qubits[:4])\n",
+    "subset_reset_conf_matx = estimate_joint_reset_confusion(qc, subset, \n",
+    "                                                        joint_group_size=len(subset), \n",
+    "                                                        show_progress_bar=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for row in subset_reset_conf_matx[subset]:\n",
+    "    pr_sucess = row[0]\n",
+    "    print(pr_sucess)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_readout.py
+++ b/tests/test_readout.py
@@ -80,10 +80,8 @@ def test_reset_confusion_consistency(qvm):
     num_trials = 10
     qubits = (0, 1)
 
-    active_reset = estimate_joint_reset_confusion(qvm, qubits, num_trials, len(qubits))[qubits]
     passive_reset = estimate_joint_reset_confusion(qvm, qubits, num_trials, len(qubits),
                                                    use_active_reset=False)[qubits]
 
     atol = .1
-    np.testing.assert_allclose(active_reset, passive_reset, atol=atol)
     np.testing.assert_allclose(passive_reset[:, 0], np.ones(4).T, atol=atol)


### PR DESCRIPTION
The previous implementation of estimating reset errors first ran a prep program that prepared the state-to-be-reset and then didn't measure the qubits, because the point was to see if the subsequent program would reset the state properly. However, this is unsupported by the QPU so I've had to add measurements at the end of the prep program. I'm not sure if this is the proper approach, but the prep program is ran up to 10 times until the measurement reports that the proper state is prepared (before proceeding to the reset program). @ntezak it was suggested you might have thoughts on the best approach.  

I threw in some minor improvements as well, like adding usage examples to an already existing readout_fidelity notebook and providing the option to see a progress bar. 