### PR TITLE
Refactor DFE to use pyquil measure_observables

### DIFF
--- a/forest_benchmarking/dfe.py
+++ b/forest_benchmarking/dfe.py
@@ -192,9 +192,7 @@ class DFEdata:
     count: List[int]
     """number of shots used to calculate the `expectation`"""
 
-
-def acquire_dfe_data(experiment, quantum_machine: QuantumComputer, var: float = 0.01) -> Tuple[
-    DFEdata, DFEdata]:
+def acquire_dfe_data(experiment, quantum_machine: QuantumComputer, var: float = 0.01) -> Tuple[DFEdata, DFEdata]:
     """
     Estimate state/process fidelity by exhaustive direct fidelity estimation.
 
@@ -305,7 +303,6 @@ class DFEestimate:
     fid_std_err_est: float
     """Standard deviation of the fidelity point estimate, after considering the calibration."""
 
-
 def direct_fidelity_estimate(data: DFEdata, cal: DFEdata, type: str) -> DFEestimate:
     """
     Estimate state or process fidelity by exhaustive direct fidelity estimation.
@@ -317,7 +314,7 @@ def direct_fidelity_estimate(data: DFEdata, cal: DFEdata, type: str) -> DFEestim
     pauli_est = data.expectation / np.abs(cal.expectation)
     var_est = ratio_variance(data.expectation, data.variance, cal.expectation, cal.variance)
 
-    temp_data = {'dimension': data.dimension, 'expectation': pauli_est, 'variance': var_est}
+    temp_data = { 'dimension': data.dimension, 'expectation': pauli_est, 'variance': var_est }
 
     if type == 'state':
         fid = aggregate_state_dfe(temp_data)
@@ -332,13 +329,12 @@ def direct_fidelity_estimate(data: DFEdata, cal: DFEdata, type: str) -> DFEestim
         out_pauli=data.out_pauli,
         dimension=data.dimension,
         number_qubits=data.number_qubits,
-        pauli_point_est=pauli_est,
+        pauli_point_est=pauli_est ,
         pauli_var_est=var_est,
         fid_point_est=fid['expectation'],
         fid_var_est=fid['variance'],
         fid_std_err_est=np.sqrt(fid['variance'])
     )
-
 
 def aggregate_process_dfe(data: dict):
     if isinstance(data['dimension'], int):
@@ -360,8 +356,7 @@ def aggregate_state_dfe(data: dict):
     }
 
 
-def ratio_variance(a: np.ndarray, var_a: np.ndarray, b: np.ndarray,
-                   var_b: np.ndarray) -> np.ndarray:
+def ratio_variance(a: np.ndarray, var_a: np.ndarray, b: np.ndarray, var_b: np.ndarray) -> np.ndarray:
     """
     Given random variables 'A' and 'B', compute the variance on the ratio Y = A/B. Denote the
     mean of the random variables as a = E[A] and b = E[B] while the variances are var_a = Var[A]
@@ -385,4 +380,4 @@ def ratio_variance(a: np.ndarray, var_a: np.ndarray, b: np.ndarray,
     TODO: add in covariance correction?
 
     """
-    return (np.asarray(a) / np.asarray(b)) ** 2 * (var_a / np.asarray(a) ** 2 + var_b / np.asarray(b) ** 2)
+    return (np.asarray(a)/np.asarray(b))**2 * (var_a/np.asarray(a)**2 + var_b/np.asarray(b)**2)

--- a/forest_benchmarking/graph_state.py
+++ b/forest_benchmarking/graph_state.py
@@ -28,7 +28,7 @@ def create_graph_state(graph: nx.Graph, use_pragmas=True):
     for q in graph.nodes:
         program += H(q)
 
-    if use_pragmas > 0:
+    if use_pragmas:
         program += Pragma('COMMUTING_BLOCKS')
     for a, b in graph.edges:
         if use_pragmas:

--- a/forest_benchmarking/graph_state.py
+++ b/forest_benchmarking/graph_state.py
@@ -7,7 +7,7 @@ from pyquil.quilbase import Pragma
 from forest_benchmarking.compilation import basic_compile
 
 
-def create_graph_state(graph: nx.Graph):
+def create_graph_state(graph: nx.Graph, use_pragmas=True):
     """Write a program to create a graph state according to the specified graph
 
     A graph state involves Hadamarding all your qubits and then applying a CZ for each
@@ -21,18 +21,23 @@ def create_graph_state(graph: nx.Graph):
     how well we've done according to expected parities.
 
     :param graph: The graph. Nodes are used as arguments to gates, so they should be qubit-like.
+    :param use_pragmas: Use COMMUTING_BLOCKS pragmas to hint at the compiler
     :return: A program that constructs a graph state.
     """
     program = Program()
     for q in graph.nodes:
         program += H(q)
 
-    program += Pragma('COMMUTING_BLOCKS')
+    if use_pragmas > 0:
+        program += Pragma('COMMUTING_BLOCKS')
     for a, b in graph.edges:
-        program += Pragma('BLOCK')
+        if use_pragmas:
+            program += Pragma('BLOCK')
         program += CZ(a, b)
-        program += Pragma('END_BLOCK')
-    program += Pragma('END_COMMUTING_BLOCKS')
+        if use_pragmas:
+            program += Pragma('END_BLOCK')
+    if use_pragmas:
+        program += Pragma('END_COMMUTING_BLOCKS')
 
     return program
 

--- a/tests/test_dfe.py
+++ b/tests/test_dfe.py
@@ -4,8 +4,8 @@ import numpy as np
 
 from pyquil import Program
 from pyquil.gates import CZ, RX, CNOT, H
-from forest_benchmarking.dfe import generate_process_dfe_experiment, acquire_dfe_data, \
-    direct_fidelity_estimate, generate_state_dfe_experiment, ratio_variance
+from forest_benchmarking.dfe import exhaustive_state_dfe, acquire_dfe_data, \
+    direct_fidelity_estimate, exhaustive_process_dfe, ratio_variance
 
 def test_exhaustive_gate_dfe_noiseless_qvm(qvm, benchmarker):
     qvm.qam.random_seed = 1

--- a/tests/test_dfe.py
+++ b/tests/test_dfe.py
@@ -1,64 +1,51 @@
-from math import pi
-
-import numpy as np
-
+from forest_benchmarking.dfe import exhaustive_state_dfe, exhaustive_process_dfe, ratio_variance, \
+    monte_carlo_process_dfe
 from pyquil import Program
-from pyquil.gates import CZ, RX, CNOT, H
-from forest_benchmarking.dfe import exhaustive_state_dfe, acquire_dfe_data, \
-    direct_fidelity_estimate, exhaustive_process_dfe, ratio_variance
-
-def test_exhaustive_gate_dfe_noiseless_qvm(qvm, benchmarker):
-    qvm.qam.random_seed = 1
-    process_exp = generate_process_dfe_experiment(Program([RX(pi / 2, 0)]), compiler=benchmarker)
-    data, cal = acquire_dfe_data(process_exp, qvm, var=0.01,)
-    est = direct_fidelity_estimate(data, cal, 'process')
-    assert est.fid_point_est == 1.0
-    assert est.fid_var_est == 0.0
-    assert all([exp == 1.0 for exp in data.expectation])
-    assert all(np.abs(cal) == 1.0 for cal in cal.expectation)
-
-    process_exp = generate_process_dfe_experiment(Program([CZ(0, 1)]), compiler=benchmarker)
-    data, cal = acquire_dfe_data(process_exp, qvm, var=0.01, )
-    est = direct_fidelity_estimate(data, cal, 'process')
-    assert est.fid_point_est == 1.0
-    assert est.fid_var_est == 0.0
-    assert all([exp == 1.0 for exp in data.expectation])
-    assert all(np.abs(cal) == 1.0 for cal in cal.expectation)
-
-    process_exp = generate_process_dfe_experiment(Program([CNOT(0, 1)]), compiler=benchmarker)
-    data, cal = acquire_dfe_data(process_exp, qvm, var=0.01, )
-    est = direct_fidelity_estimate(data, cal, 'process')
-    assert est.fid_point_est == 1.0
-    assert est.fid_var_est == 0.0
-    assert all([exp == 1.0 for exp in data.expectation])
-    assert all(np.abs(cal) == 1.0 for cal in cal.expectation)
+from pyquil.gates import *
+from pyquil.numpy_simulator import NumpyWavefunctionSimulator
+from pyquil.operator_estimation import _one_q_state_prep
 
 
-def test_exhaustive_state_dfe_noiseless_qvm(qvm, benchmarker):
-    qvm.qam.random_seed = 1
-    state_exp = generate_state_dfe_experiment(Program([RX(pi / 2, 0)]), compiler=benchmarker)
-    data, cal = acquire_dfe_data(state_exp, qvm, var=0.01,)
-    est = direct_fidelity_estimate(data, cal, 'state')
-    assert est.fid_point_est == 1.0
-    assert est.fid_var_est == 0.0
-    assert all([exp == 1.0 for exp in data.expectation])
-    assert all(np.abs(cal) == 1.0 for cal in cal.expectation)
+def test_exhaustive_state_dfe():
+    texpt = exhaustive_state_dfe(program=Program(X(0), X(1)), qubits=[0, 1])
+    assert len(texpt) == 3 ** 2 - 1
 
-    state_exp = generate_state_dfe_experiment(Program([H(0), H(1), CZ(0, 1)]), compiler=benchmarker)
-    data, cal = acquire_dfe_data(state_exp, qvm, var=0.01,)
-    est = direct_fidelity_estimate(data, cal, 'state')
-    assert est.fid_point_est == 1.0
-    assert est.fid_var_est == 0.0
-    assert all([exp == 1.0 for exp in data.expectation])
-    assert all(np.abs(cal) == 1.0 for cal in cal.expectation)
 
-    state_exp = generate_state_dfe_experiment(Program([H(0), CNOT(0, 1)]), compiler=benchmarker)
-    data, cal = acquire_dfe_data(state_exp, qvm, var=0.01,)
-    est = direct_fidelity_estimate(data, cal, 'state')
-    assert est.fid_point_est == 1.0
-    assert est.fid_var_est == 0.0
-    assert all([exp == 1.0 for exp in data.expectation])
-    assert all(np.abs(cal) == 1.0 for cal in cal.expectation)
+def test_exhaustive_dfe():
+    texpt = exhaustive_process_dfe(program=Program(Z(0)), qubits=[0])
+    assert len(texpt) == 7 ** 1 - 1
+
+
+def test_exhaustive_dfe_run():
+    wfnsim = NumpyWavefunctionSimulator(n_qubits=1)
+    process = Program(Z(0))
+    texpt = exhaustive_process_dfe(program=process, qubits=[0])
+    for setting in texpt:
+        setting = setting[0]
+        prog = Program()
+        for oneq_state in setting.in_state:
+            prog += _one_q_state_prep(oneq_state)
+        prog += process
+
+        expectation = wfnsim.reset().do_program(prog).expectation(setting.out_operator)
+        assert expectation == 1.
+
+
+def test_monte_carlo_dfe():
+    process = Program(CNOT(0, 1))
+    texpt = monte_carlo_process_dfe(program=process, qubits=[0, 1], n_terms=10)
+    assert len(texpt) == 10
+
+    wfnsim = NumpyWavefunctionSimulator(n_qubits=2)
+    for setting in texpt:
+        setting = setting[0]
+        prog = Program()
+        for oneq_state in setting.in_state:
+            prog += _one_q_state_prep(oneq_state)
+        prog += process
+
+        expectation = wfnsim.reset().do_program(prog).expectation(setting.out_operator)
+        assert expectation == 1.
 
 
 def test_ratio_variance():

--- a/tests/test_dfe.py
+++ b/tests/test_dfe.py
@@ -23,7 +23,7 @@ def test_exhaustive_dfe_run():
     for setting in texpt:
         setting = setting[0]
         prog = Program()
-        for oneq_state in setting.in_state:
+        for oneq_state in setting.in_state.states:
             prog += _one_q_state_prep(oneq_state)
         prog += process
 
@@ -40,7 +40,7 @@ def test_monte_carlo_dfe():
     for setting in texpt:
         setting = setting[0]
         prog = Program()
-        for oneq_state in setting.in_state:
+        for oneq_state in setting.in_state.states:
             prog += _one_q_state_prep(oneq_state)
         prog += process
 


### PR DESCRIPTION
In the spirit of #4 and #17, this re-writes DFE to use the shared set of datastructures exposed in pyquil's operator_estimation.py.

As a bonus: I've implemented monte-carlo DFE, and for exhaustive dfe I've made it exhaustive over the input states (+1 and -1 eigenstates for each of X, Y, Z instead of always preparing the +1 eigenstate). This addresses the same issue as #29.

One large caveat is that the `acquire` function does readout symetrization and calibration which pyquil's `measure_observables` has not learned how to do yet. For full feature parity, the symmetrization and calibration code should be ported to those routines. As a benefit, readout calibration will automatically become available and be shared among dfe, state, and process tomography as well as any e.g. VQE-style algorithms that use `measure_observables`