### PR TITLE
Add fine-grained control to Quantum Volume via data frame workflow

### DIFF
--- a/examples/quantum_volume.ipynb
+++ b/examples/quantum_volume.ipynb
@@ -2,9 +2,27 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 1, 2, 3]\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX8AAAD8CAYAAACfF6SlAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzt3XlcVGX7x/HPLSpC7immuRUgSqImoGLqg0sa7prlkntlaZamVtqiWPZoPqTlk5JL5pqaG1m55pZ7rrknYP1SM0HFHVLg/v0xgw/iICgzc2a53q/XvIQzZ865GPV7Dvfc51xKa40QQgj3ks/oAoQQQtifhL8QQrghCX8hhHBDEv5CCOGGJPyFEMINSfgLIYQbkvAXQgg3JOEvhBBuSMJfCCHcUH6jC8hOqVKldOXKlY0uQwghnMrevXvPa61L57Sew4Z/5cqV2bNnj9FlCCGEU1FK/V9u1pNhHyGEcEMS/kII4YYk/IUQwg1J+AshhBuS8BdCCDck4S+EEG5Iwl8IIdyQhL8QQrghh73ISwirSEiAWbPg4EG4fBmKFYMaNaBPHyid40WQQrgsCX/hmnbvhrFjYdUq0/cpKf97btkyGDUKIiJgxAgIDTWmRiEMJMM+wvVER0N4OMTEmEI/c/ADJCeblsXEmNaLjjaiSiEMJWf+wrVER8OwYXDjRs7ram1ab9gw0/f9+9u2NiEciJz5C9exe7fF4O8OlAWKAlWAGVlfl3EAkBsJCjci4S9cx9ixpiGdLEYAfwBXgBXA+8DerCslJ5teL4SbsEr4K6VmKqUSlFKHs3leKaUmKaXilFIHlVK1rbFfIW5LSDB9uKv1XU89AXiav1bmR3zWlbSGlSshMdGmZQrhKKx15j8LeOYez0cA/uZHP0A+YRPWNWvWPZ8eAHgDVTENAbW0tJJSOW5HCFdhlfDXWv8MXLzHKu2AOdpkJ1BcKVXWGvsWAjDN4886qyeTKcBVYAvQkf/9JnCH5GQ4dMgm5QnhaOw15v8ocCrT96fNy+6glOqnlNqjlNqTKL9+i/tx+XKOq3gADTD948v2V8+kJOvVJIQDc6gPfLXW07TWIVrrkNJy9aW4H8WK5XrVVCyM+WcoUcIa1Qjh8OwV/meACpm+L29eJoR11KgBhQrdtTgBWAhcA9KANcACoKmlbXh5QVCQDYsUwnHYK/xXAD3Ns37qAZe11mfttG/hDnr3trhYYRriKQ+UAIYBnwFtLayblpaG7tXLRgUK4VisNdVzAbADCFBKnVZKvaiUelUp9ap5lZXASSAOmI5p8oUQ1uPjAxERaKXuWFwa2AxcwjTP/xDwsoWXpyvF+oIFadChA2vXrkVbmDIqhCuxyu0dtNZdc3heA69ZY19CZOefIUNgxQo809Lu+7X5vLxo+tNPnI+PZ9CgQRQvXpzIyEiaN2+OynJAEcIVONQHvkI8qMTERJq88w5zatRAe3vf34u9vSEqCo+6denWrRuHDx9m0KBBDBkyhLCwMFatWiW/CQiXI+EvnN6xY8eoV68e4eHhvLhnDyoqyhToOZ2xK3U7+DPf1M3Dw4MuXbpw6NAhhgwZwltvvUXdunX58ccf5SAgXIfW2iEfwcHBWoicrFu3Tvv4+OhZs2bd+cTu3Vp37Kh1oUJae3lpbbqBg9ag/8mf37S8Y0fTejlIS0vTixcv1kFBQTokJESvWLFCp6en2+gnEiJvgD06FxmrtIOeyYSEhOg9cpdFcQ/Tpk1j5MiRLFq0iH/961+WV0pMNN2y4dAhSEri9PXrrDx1in7bt993J6/09HRiYmL48MMP8fDwYOTIkbRt21Y+ExAORSm1V2sdkuN6Ev7C2aSlpfHOO++wYsUKfvzxR/z9/XP92oSEBAICArh48eIDh3Z6ejorVqxg9OjRAIwcOZJ27dqRL5+Mogrj5Tb85V+rcCrXr1/n2WefZc+ePezcufO+gh/Ax8eHokWLEhcX98A15MuXj/bt27Nv3z5Gjx7NRx99xJNPPsnSpUtJT09/4O0KYU8S/sJpnDlzhoYNG1KyZEnWrl1LyZIlH2g7oaGhWOO3SqUUbdu2Ze/evYwZM4axY8dSq1YtlixZIgcB4fAk/IVT2L9/P/Xq1eP555/nq6++omDBgg+8rdDQUHbv3m212pRStGnTht27dzN27FjGjx9PzZo1+fbbb+UgIByWhL9weCtWrKB58+ZMnDiR4cOH5/kDVmuHfwalFK1atWLXrl2MHz+eCRMmEBQUxMKFC0l7gAvPhLAlCX/hsLTWfPrpp/Tv358ff/yRTp06WWW7wcHBHDhwgNTUVKtsLyulFBEREezYsYMJEyYwadIkqlevzjfffCMHAeEwJPyFQ7p16xavvvoqs2fPZseOHdSpU8dq2y5WrBjlypXj2LFjVtumJUopWrRowbZt25g0aRJTpkzhiSeeYN68eTY78AiRWxL+wuFcunSJli1bcvr0abZt20bFihWtvg9bDf1YopTi6aefZsuWLUyePJlp06YRGBjInDlz5CAgDCPhLxzKyZMnqV+/PoGBgXz33XcUKVLEJvux1oyf+6GUomnTpmzevJmpU6fy1VdfUa1aNWbPni0HAWF3Ev7CYWzbto2nnnqKAQMG8Pnnn5M/v1VuOmuRPc/8s1JK0bhxYzZv3sz06dOZNWsWVatW5euvv+bWrVuG1CTcj4S/cAjffPMNHTp0YObMmQwcONDm+6tVqxZHjx7ln3/+sfm+7iU8PJyNGzcyc+ZM5s2bR0BAAF999ZUcBITNSfgLQ2mtGT16NO+++y4bNmwgIiLCLvv19vbG39+fgwcP2mV/OWnUqBHr169nzpw5LFy4kCpVqjB9+nRu3rxpdGnCRUn4C8OkpKTQvXt3Vq5cyc6dO6levbpd9x8SEmLY0E92GjRowLp165g3bx6LFy+mSpUqTJ06VQ4Cwuok/IUhEhMTadq0Kbdu3WLTpk088sgjdq/ByHH/nDz11FOsXbuWBQsWsHz5cvz9/YmOjjZ8mEq4Dgl/YXdHjx6lbt26NG7cmIULF+Ll5WVIHUbM+LlfYWFhrF69mm+//Zbvv/8ePz8/pkyZIgcBkWcS/sKufvrpJ8LDwxk1ahRjxowx9DbIQUFBnDx5kuvXrxtWQ27VrVuXlStXsnTpUlauXImfnx9ffPEFKSkpRpcmnJSEv7CbadOm0b17d5YsWUKvXr2MLocCBQoQFBTEvn37jC4l1+rUqcMPP/zA8uXLWbt2LX5+fkyaNInk5GSjSxNORsJf2FxaWhrDhg3j008/ZcuWLTRq1Mjokm5zxA99cyMkJIQVK1awYsUKNmzYgJ+fH5999pkcBESuSfgLm7p27RodO3Zk79697Nix476br9iaI3/omxu1a9cmJiaGH3/8kZ9//hlfX18mTJjAjRs3jC5NODgJf2Ezp0+fpmHDhjz88MOsWbPmgZuv2JIzfOibG7Vq1WLZsmWsWrWKbdu24evrS1RUlFN8niGMIeEvbGLfvn2EhYXRuXPnPDdfsaWAgADOnTtHUlKS0aVYRc2aNVm6dClr1qxh165d+Pr6Mn78eK5du2Z0acLBSPgLq/vuu+9o0aIFn332mVWar9iSh4cHtWvXdomz/8xq1KjB4sWL+emnn9i7dy++vr588sknchAQt0n4C6vJaL4yYMAAVq5cybPPPmt0Sbni7OP+91K9enUWLVrEhg0bOHDgAL6+vowdO5arV68aXZowmIS/sIpbt27xyiuv3G6+EhoaanRJueasM37uxxNPPMGCBQvYtGkThw8fxtfXl48//pgrV64YXZowiIS/yLNLly4RERHBX3/9ZbPmK7bkymf+WVWrVo358+ezZcsWjh8/jq+vLx999BGXL182ujRhZxL+Ik9OnjxJWFgY1atXt2nzFVt67LHHSElJ4ezZs0aXYjcBAQHMnTuXbdu2ERsbi5+fH6NHj+bSpUtGlybsRMJfPLCM5isDBw7ks88+w8PDw+iSHohSipCQEJf70Dc3qlSpwpw5c9i+fTu///47fn5+REZGuszsJ5E9CX/xQObPn0+HDh34+uuvee2114wuJ8/caejHEn9/f2bNmsWuXbv4888/8ff3Z+TIkVy8eNHo0oSNSPiL+6K1JjIykvfee48NGzbwzDPPGF2SVbh7+Gfw9fVl5syZ/PLLL/z1119UqVKF999/nwsXLhhdmrAyCX+RaykpKbzwwgusXr3akOYrtpQx40drbXQpDuHxxx9nxowZ7N69m4SEBKpUqcK7777L+fPnjS5NWImEv8iVjOYraWlpbNy40ZDmK7ZUrlw5PD09+eOPP4wuxaE89thjTJs2jX379nHx4kUCAgIYPnw4iYmJRpcm8sgq4a+UekYp9ZtSKk4pNdzC872VUolKqQPmx0vW2K+wj4zmK02aNGHBggWGNV+xNVe5z48tVKpUiS+//JL9+/dz5coVqlatyjvvvCMHASeW5/BXSnkAk4EIIBDoqpQKtLDqIq11LfNjRl73K+xj3bp1hIeHExkZyUcffWRo8xVbk3H/nFWsWJEpU6Zw4MABrl27RtWqVXnrrbc4d+6c0aWJ+2SN/8l1gDit9Umt9U1gIdDOCtsVBps6dSo9evRgyZIl9OzZ0+hybE7CP/cqVKjA5MmT+fXXX0lJSaFatWoMHTqUv//+2+jSRC5ZI/wfBU5l+v60eVlWzyqlDiqlliilKlhhv8JG0tLSGDp0KBMmTHC45iu2FBISwr59+0hPTze6FKdRvnx5/vvf/3L48GFSU1MJDAzkzTffdKsL5pyVvX6H/x6orLWuAawDZltaSSnVTym1Rym1R8YSjZHRfGX//v0O2XzFlkqWLEmpUqX47bffjC7F6ZQrV47PP/+cI0eOAKZ7CQ0aNIi//vrL4MpEdqwR/meAzGfy5c3LbtNaX9Ba/2P+dgYQbGlDWutpWusQrXVI6dKlrVCauB8ZzVdKlSrF6tWrHbL5iq3J0E/elC1blokTJ3L06FHy589P9erVef311zlz5kzOLxZ2ZY3w3w34K6UeU0oVBLoAKzKvoJQqm+nbtsAxK+xXWNHevXupV68eXbp0YcaMGQ7bfMXWZMaPdTzyyCN8+umnHDt2DE9PT4KCgnjttdc4depUzi8WdpHn8NdapwIDgTWYQv1brfURpdSHSqm25tXeUEodUUr9CrwB9M7rfoX1xMTE8Mwzz/D555/zzjvvOHTzFVuTM3/rKlOmDFFRURw/fpyHHnqIWrVqMWDAAP7880+jS3N7ylGvaAwJCdFyBmZbWmsmTJjAxIkTiYmJISQkxOiSDHft2jXKlCnDpUuXKFCggNHluJzExEQ+/fRTpk+fznPPPceIESOoVKmS0WW5FKXUXq11jv+ZXXfStrinjOYrc+bMYceOHRL8ZoULF6Zy5cocPnzY6FJcUunSpRk3bhy//fYbJUuWpHbt2vTr10+urDaAhL8bSkpKut18ZevWrVSoIDNvM5OhH9srVaoU//73vzlx4gQ+Pj4EBwfz0ksvcfLkSaNLcxsS/m4mPj6e+vXrO3XzFVuTD33t5+GHH2bMmDHExsZSrlw56tSpQ9++fYmPjze6NJcn4e9Gtm3bRoMGDXj99deduvmKrcmZv/2VLFmSDz/8kNjYWCpWrEjdunXp06cPcXFxRpfmsiT83UTm5isDBgwwuhyHVrNmTU6cOEFycrLRpbidEiVKEBkZSVxcHJUrVyYsLIxevXoRGxtrdGkuR8LfxWmtGTVqFO+//75LNV+xJU9PT6pVq8aBAweMLsVtFS9enFGjRhEXF4efnx/169enR48ecvW1FUn4u7CM5itr1qxxueYrtpbR3EUYq1ixYnzwwQfEx8dTtWpVGjZsyAsvvMDx48eNLs3pSfi7qISEBJo0aXK7+UqZMmWMLsmpyLi/YylatCjvvfce8fHxVK9enUaNGtG1a1eOHj1qdGlOS8LfBR09epR69erRtGlTl26+Yksy48cxFSlShBEjRhAfH0/NmjVp3LgxnTt3lusyHoCEv4txp+YrthQYGMjp06e5cuWK0aUIC4oUKcLw4cOJj48nODiYZs2a8fzzz3Po0CGjS3Makgwu5Msvv3Sr5iu2lD9/fmrWrMnevXuNLkXcQ+HChXn77beJj4+nTp06NG/enE6dOnHw4EGjS3N4Ev4uIC0tjSFDhjBx4kS2bt3qNs1XbE3G/Z3HQw89xLBhw25fxNiiRQs6duwoM7buQcLfyV27do0OHTpw4MABduzYgZ+fn9EluQyZ8eN8vL29GTJkCPHx8TRq1IiWLVvSvn179u/fb3RpDkfC34llNF/x8fFx2+YrtiRn/s7L29ubwYMHEx8fT5MmTWjdujVt27aVYbxMJPydVEbzla5duzJ9+nS3bb5iS35+fly6dAlpKeq8vLy8eOONN4iPj6d58+a0a9eO1q1by0EdCX+nlNF8ZdKkSbz99ttu3XzFlvLly0dISIhM+XQBhQoVYuDAgcTFxREREUHHjh1p2bIlu3btMro0w0j4OxGtNVFRUbz22musWrWKjh07Gl2Sy5OhH9dSqFAhXnvtNeLi4mjTpg3PPfccERER7Ny50+jS7E7C30ncunWLfv36MW/ePHbu3CnNV+xEwt81eXp60r9/f2JjY2nfvj2dO3emRYsWbN++3ejS7EbC3wlkNF85e/YsW7ZskeYrdpQx48dR252KvPH09OSVV14hNjaWTp068cILL/D000+zdetWo0uzOQl/B5cxbzkoKEiarxigQoUKaK05ffq00aUIGypYsCAvv/wyJ06coEuXLvTs2ZOmTZvy888/3//GEhJg/Hjo3h3atDH9OX48ONrEAa21Qz6Cg4O1u9uyZYsuU6aMnjx5stGluLVWrVrpZcuWGV2GsKObN2/qmTNnal9fXx0eHq43btyY84t++UXrDh20LlTI9ID/Pby8TMs6dDCtZ0PAHp2LjJUzfwc1b948OnbsyOzZs6X5isFk3N/9FChQgD59+nD8+HF69+7NSy+9RHh4OBs3brQ8BBgdDeHhEBMDKSmmR2bJyaZlMTGm9aKj7fFj3JOEv4PR5uYrH3zwARs3bqRFixZGl+T2JPzdV/78+enVqxfHjx+nb9++vPLKK/zrX/9i/fr1/zsIREfDsGFw44bpPP9etDatN2yY4QcAZfEo5gBCQkK0u82vTklJoW/fvvz+++/ExMTIPfgdREJCAgEBAVy8eFGuqXBzqampLFy4kDFjxlCqVCk+7dKFOu+8g7px4471LgIvAmuBUsBYoFvWjXl7w+bNYOWZe0qpvVrrHDcqZ/4OIqP5Snp6Ohs2bJDgdyA+Pj4ULVpUmokL8ufPT/fu3Tly5AgDBgzgyogRpGcJfoDXgILAOWA+0B84knWl5GQYO9bWJWdLwt8BHDlyhLp169K0aVO++eYbab7igKS5i8jMw8ODbs2a0Sw1FY8sz10HlgIfAYWBBkBbYG7WjWgNK1caNgtIwt9ga9eupXHjxnz44YfSfMWBybi/uMusWVgaBDwB5AeqZFpWEwtn/gBKwaxZ1q8tFyRpDPTll1/Ss2dPli5dSo8ePYwuR9yDhL+4y8GDd8/qAa4BRbMsKwZctbSN5GQwqPtYfkP26ubS0tIYNmwYq1atYuvWrXIPficQHBzMgQMHSE1NJX9++W/jLpKTk0lISLj9OHfu3O2vu2/aRG0LrykMZG3+eQXI9vLMpCRrlpxr8q/Yzq5du0bXrl25fv06O3bsoESJEkaXJHKhWLFilCtXjmPHjhEUFGR0OeIBpaWlcfHixbuCPLuAv3XrFj4+Pnc8ypQpw6OPPkrxSpXgzJm79lEFSAViAX/zsl+BJ7IryqAMkPC3o9OnT9OmTRuCg4OZMmWK3IPfyWQM/Uj4O5Zr165ZDHFLAX/x4kWKFSt2O8Qzh3pwcPAdAe/j40ORIkWyn96blgb79t019PMQ0BEYCcwADgDfARZvGeflBQb9e5Lwt5O9e/fSrl07Bg0axLBhw2S+uBPKmPHTt29fo0txaampqZw/f/6eIZ75obW+K8h9fHyoVKkSderUuWNZqVKlrDds17s3jBpl8akpQF/AB3gYiCabM3+tTdsxgIS/HcTExPDyyy8zbdo0OnToYHQ54gGFhoYyb948o8twOlprrl69mqsgP3fuHJcvX6ZkyZJ3DbX4+Pjg6+t7V8gXLlzYmB/MxwciItAxMagsF8uWBGJyer1S0LIllC5tqwrvScLfhrS5+crnn3/OqlWr5B78Tq5WrVocPXqUf/75B09PT6PLMdTNmzdJTEzM9XBLgQIF7gpyHx8f/P39eeqpp+54rmTJknh4ZJ0975jO9e1L0ZgYHujKHC8vGDHC2iXlmoS/jdy6dYsBAwawe/duduzYIffgdwHe3t74+/tz8OBBQkNDjS7HqrTWXLp0KVdBnpCQwNWrVylduvRdZ+E+Pj4EBATcEfClS5fG29vb6B/R6vbu3Uu7V19lZvv2PL1mzV23eLgnb2+IirL6rR3uh4S/DSQlJdGpUye8vb3ZsmWL3IPfhWQ0d3GG8E9JSbnj7Pxewy2JiYl4eXlZDPMnnniCxo0b37GsRIkSbn1B4vLly+nXrx/Tpk2jeYcO/7u5W3LyvW/uppTpjD8qCvr3t1/BFlgl/JVSzwCfAx7ADK31uCzPewJzgGDgAtBZa/2HNfbtaOLj42nVqhURERFERUU5za+vIndCQ0MN6/eanp5OUlJSjmPmGV8nJydbHDcvU6YMQUFBd4W8uw9l5UbmodzVq1cTHBxseqJ/fwgNNd2rZ+VKU8gnJ//vhV5epoNCy5amoR4HGALOc/grpTyAycDTwGlgt1Jqhdb6aKbVXgSStNZ+SqkuwCdA57zu29Fs3bqVTp06MWrUKPobfFQXthEaGsoXX3xhte3duHEj10Mt58+fp0iRIhanKdasWfOu5cWKFZNZZVaUeSh3586dlC9f/s4VQkJg6VLTvXpmzTJduZuUZJrHHxRkmtVj0Ie7lljjzL8OEKe1PgmglFoItAMyh387INL89RLgC6WU0o56P+kHMG/ePIYMGcLcuXPlHvwuLCgoiJMnT3L9+nUeeuihu55PS0vjwoULuZqmeO7cOVJTUy1OUyxfvvwd884zpinKtSHGyDyUu3Xr1nvPMCpdGt56y37FPSBrhP+jwKlM358G6ma3jtY6VSl1GdP01/NW2L+hMpqvzJ07l40bN/LEE9lexyeckNaa69ev3xHiZcqUYfDgwXh7e98V8ElJSRQvXtzicEtoaOhdIX/Pi4iEQ8gYym3ZsiX/+c9/XGYo16E+8FVK9QP6AVSsWNHganKWkpJCnz59+OOPP9i5c6fcg99JpKamZjtN0dJZOnDHeLmXlxe///47rVu3pm7duneE/MMPPyz3/nEhW7Zs4bnnniMyMpJXX33V6HKsyhr/Ss8Amecxljcvs7TOaaVUfkw3ubuQdUNa62nANDB18rJCbTaTkJBA+/btqVixIhs2bJB78BtIa82VK1dyFeQJCQlcvnyZhx9+2OLMFl9f37uGYbIO78yePZvVq1czePBgg35iYQ8ZQ7nz5s2jefPmRpdjddYI/92Av1LqMUwh34W7O5atAHoBO4BOwAZnHu8/cuQIrVu3pkePHkRGRrr1lDdbyXwRUW5mt3h6elq8AVdAQAANGza8Y3leLyIKDQ3lo48+suJPKxyJuwzl5jn8zWP4A4E1mKZ6ztRaH1FKfQjs0VqvAL4C5iql4jC1t+yS1/1aVUKC6dP5gwfh8mUoVgxq1IA+fe76dH7NmjX06NGDTz/9VO7Bfx8yLiLK7TTFa9eu3b6IKOuZeLVq1e4I+NKlS9v1N6+AgIDb4/tyV1bXkjGU+3//93/s2rULHx8fo0uyGfdu4L57t2le7qpVpu8z350vY15uRIRpXm5oKNHR0YwePZrFixfTsGFD29bmBFJSUnI9bp6YmIi3t7fFmS2WLvsvXry4Q/9GFR4eznvvvcfTTz9tdCnCSs6dO0f79u2pXLkyX3/9NYUKFTK6pAeS2wbu7vvJVE5X5GVcoBETg16zhiX16vH5mTNs27YNX19f+9ZqJ+np6bfvdZ6baYr//POPxRAvW7bs7XnnmS/xd6WLiDJu7yzh7xoyhnJ79uxJZGSkW8zAcs/wzwj+3NyLQ2vUjRu02bSJluPH85CTBX/GRUS5GW65cOECRYsWtXg2/uSTT961vGjRom7xn8SSkJAQFi5caHQZwgoyhnInTJhA9+7djS7Hbtxv2Gf3bggPvyP4vwBmAYeAruavLfL2hs2bDb00Oy0t7a57nd/rLD0tLc3iuLmlgC9VqhQFChQw7GdzJidPnqRRo0acPn3a6FJEHkRHR/Phhx+yePFiGjRoYHQ5ViHDPtkZO/bOe24A5YD3MX1inWzpNRmSk02vX7rUauVorS12IsruTD3jQ0ZLIZ55znnme52769m5LT322GOkpKRw9uxZypYta3Q54j5l9NFevXo1W7duddmh3Htxr/BPSDB9uJvlt52O5j/3YLo8OVtam27alJh4z3t03Lp16/bZeW76hHp4eFg8G/f19SUsLOyO5XIRkWNQShESEsKePXto06aN0eWI+3D16lW6devGjRs32L59u9vO2HKvFJk1K8+bSEtP58jQoWyvXz/bs/QrV67cvogo63CLv7//XdMULd0jRji+jA99Jfydx6lTp2jTpg2hoaFMmTLFrYc53Sv8Dx68q9ny/fK4eZMLGzey33zv84yLiDKHfMmSJR16mqKwjlDz9F/hHDL6aA8ePJihQ4e6/XCoe4X/5ctW2UzjWrVoPHWqVbYlnFdGYxettdsHiaPLaL4yffp02rdvb3Q5DsG9Tk+LFbPOdtx0jFDcqVy5cnh6evLHH38YXYrIhtaa8ePH88Ybb7BmzRoJ/kzcK/xr1AALV+2lAilAmvmRYl5mkZeXqTGDEJiGfmx+Jbp4IDdv3uTll19mwYIF7Nixg9q1axtdkkNxr/Dv3dvi4jGAFzAOmGf+ekw2m9Dp6dluR7ifjA99hWNJSkrimWeeISEhgS1bttzddUu4Wfj7+Jju1ZNlfDYS0FkekRZeng78kJ7O0HHj+Pvvv21bq3AKEv6OJy4ujrCwMGrVqsXy5cuuj0W9AAAXHklEQVTv3XXLjblX+IPpJm0PeAfIfN7e1I2J4datWwQGBjJkyBA5CLi5kJAQ9u3bR3p6utGlCEzNVxo0aMCbb77JhAkTXKbrli24X/iHhkJUlOlWDffD2xuiovBp2ZJJkyZx+PBh0tPTCQwMZPDgwfz111+2qVc4tJIlS1KqVCl+++03o0txe3PnzuXZZ59l7ty5vPLKK0aX4/DcL/wB+vf/3wEgpyl6St0Ofvr3v724XLlyfPbZZxw5coR8+fJRvXp13njjDc6cydrETLg6GfoxVnp6Oh988AGjRo1i06ZNcqfVXHLP8AdTkG/eDB06mGYAZR0K8vIyLe/QwbRepuDPrGzZskyYMIGjR49SsGBBgoKCGDhwoNzwy43IjB/jJCcn061bN9avX8/OnTsJDAw0uiSn4b7hD6a7cy5dCn/+CaNHQ48e0Lq16c/Ro03Lly7N1V08H3nkEaKiojh+/Dje3t7UrFmTAQMGcOrUKTv8IMJIcuZvjHPnztGkSRPy5cvHhg0bXLrrli243y2d7SQxMZGoqCimT5/O888/z4gRI6hUqZLRZQkbuHbtGo888ghJSUlufa8Yezp8+DBt2rShV69ejBo1Sq6wziS3t3R27zN/GypdujSffPIJJ06coESJEtSuXZtXXnlFrgZ1QYULF6Zy5cocPnzY6FLcwpo1a2jSpAljxoxxm65btiDhb2OlSpVi7NixnDhxglKlShEcHMzLL7/M77//bnRpwooy7vMjbCs6OprevXuzbNkyXnjhBaPLcWoS/nby8MMP8/HHHxMbG8sjjzxCaGgoL774IidPnjS6NGEFMu5vW2lpaQwePJhJkyaxdetWl+m6ZSQJfzsrWbIkH330EbGxsZQvX546derQp08f4uLijC5N5IHM+LGdq1ev0r59ew4fPsz27dvdsuuWLUj4G6REiRKMHj2a2NhYKlWqRL169ejVqxexsbFGlyYeQM2aNTlx4gTJyfdsBCru06lTp2jQoAFly5Zl1apVbtt1yxYk/A1WokQJIiMjiYuLw9fXl/r169OjRw+5YtTJeHp6Uq1aNQ4cOGB0KS5jz549hIWF0bNnT6ZOnSozqaxMwt9BFC9enJEjRxIXF0dAQAANGjSge/fuHD9+3OjSRC7Jh77Ws2zZMiIiIvjiiy+k65aNSPg7mGLFivH+++8THx9PYGAgjRo1olu3bhw7dszo0kQO5EPfvMtovjJo0CBpvmJjEv4OqmjRorz77rvEx8dTo0YNwsPD6dKlC0eOHDG6NJEN+dA3b27evMlLL73EwoUL2blzpzRfsTEJfwdXpEgRhg8fTnx8PE8++SRNmjTh+eeflwuKHFBgYCCnT5/mypUrRpfidDKar5w/f56ff/6ZRx991OiSXJ6Ev5MoXLgw77zzDvHx8YSGhtKsWTM6derEwYMHjS5NmOXPn5+aNWuyd+9eo0txKnFxcdSrV48nn3ySZcuWSfMVO5HwdzKFCxfmrbfeIj4+nrCwMFq0aEHHjh1llomDkHH/+5PRfGXIkCF8+umn0nzFjiT8ndRDDz3E0KFDiY+Pp2HDhrRs2ZIOHTqwf/9+o0tzazLjJ/fmzJlDp06dpPmKQST8nZy3tzdvvvkm8fHxhIeH07p1a9q1aydDDwaRM/+cpaen8/777xMZGcnGjRul+YpBJPxdhJeXF4MGDSIuLo5mzZrRrl072rRpI7NP7MzPz49Lly6RmJhodCkOKTk5ma5du7JhwwZpvmIwCX8X4+Xlxeuvv05cXBwtWrSgffv2tGrVil9++cXo0txCvnz5CAkJkYOuBefOnaNx48Z4eHhI8xUHIOHvogoVKsTAgQOJj4+nVatWdOrUiYiICHbu3Gl0aS5Phn7udvjwYerVq8czzzzD/PnzKVSokNEluT0Jfxfn6enJgAEDiI2NpV27dnTu3JkWLVqwfft2o0tzWRL+d1q9erU0X3FAeQp/pVRJpdQ6pVSs+U+Lt9xTSqUppQ6YHyvysk/xYDw9PXn11VeJjY3l2WefpVu3bjz99NNs3brV6NJcTsaMH0dtkWpPU6ZMoU+fPixfvlyarziYvJ75DwfWa639gfXm7y1J1lrXMj/a5nGfIg8KFixIv379OHHiBJ07d6ZHjx40a9aMLVu2GF2ay6hQoQJaa06fPm10KYbJaL7y3//+l23btvHUU08ZXZLIIq/h3w6Ybf56NiB3YXISBQsW5KWXXuLEiRN069aN3r1706RJEzZv3mx0aU5PKeXW9/m5evUq7dq14/Dhw+zYsYPHH3/c6JKEBXkN/zJa67Pmr/8GymSzXiGl1B6l1E6llBwgHEiBAgXo27cvx48fp2fPnrz44ouEh4ezceNGGbbIA3cd989ovvLoo4+yatUqihcvbnRJIhs5hr9S6iel1GELj3aZ19OmpMguLSpprUOAbsBnSimLfdiUUv3MB4k9Mk/avgoUKEDv3r05fvw4ffr0oV+/fvzrX/9iw4YNchB4AO4Y/rt3777dke7LL7+U5iuOTmv9wA/gN6Cs+euywG+5eM0soFNO6wUHB2thnFu3buk5c+boKlWq6AYNGuh169bp9PR0o8tyGufOndPFixd3m/ds6dKlulSpUjomJsboUtwesEfnIr/zOuyzAuhl/roX8F3WFZRSJZRSnuavSwFPAUfzuF9hY/nz56dHjx4cPXqUV199lYEDB9KgQQPWrl0rvwnkgo+PD0WLFiUuLs7oUmxKa80nn3xyu/lKu3btcn6RcAh5Df9xwNNKqVigmfl7lFIhSqkZ5nWqAXuUUr8CG4FxWmsJfyfh4eHBCy+8wJEjRxg4cCCDBw+mfv36rF69Wg4COXD1oZ+M5iuLFi2S5itOKE/hr7W+oLVuqrX211o301pfNC/fo7V+yfz1dq11kNa6pvnPr6xRuLAvDw8PunbtyqFDhxg8eDBDhw4lLCyMlStXykEgG6484+fixYu0aNFCmq84MbnCV9wXDw8POnfuzKFDhxg6dChvv/02devW5YcffpCDQBaueuYfGxtLWFgYwcHB0nzFiUn4iweSL18+nnvuOQ4ePMjbb7/Nu+++S2hoKN9//70cBMyCg4M5cOAAqampRpdiNT///DMNGzZk6NChREVFSfMVJybhL/IkX758dOrUiQMHDvDuu+/ywQcfEBISwnfffef2B4FixYpRrlw5jh07ZnQpVpG5+Uq/fv2MLkfkkYS/sIp8+fLRsWNH9u3bxwcffEBkZCS1a9dm+fLlpKenG12eYVxh6Cej+cro0aPZtGmTNF9xERL+wqry5ctH+/bt2bdvH6NHj2bMmDE8+eSTLF261C0PAs7+oW9ycjJdunRh48aN0nzFxUj4C5tQStG2bVv27NnDxx9/zLhx46hVqxaLFy92q4OAM5/5ZzRfKVCgAOvXr6d06dJGlySsSMJf2JRSitatW/PLL78wbtw4/vOf/1CjRg0WLVpEWlqa0eXZXK1atTh69Cj//POP0aXcl8OHD1O3bl0iIiKYN2+eNF9xQRL+wi6UUrRs2ZJdu3bxn//8h4kTJxIUFMTChQtd+iDg7e2Nv78/Bw8eNLqUXMtovvLxxx8zatQoab7ioiT8hV0ppYiIiGDHjh1MnDiRSZMmUb16db755huXPQhkNHdxBpMnT5bmK25Cwl8YQilFixYt2LZtG5MmTWLKlCk88cQTzJs3z6XmxYNzjPunpaUxaNAgJk+eLM1X3ISEvzCUUoqnn36aLVu2MHnyZKZNm0ZgYCBz5sxxmYOAo8/4yWi+cvToUbZv3y7NV9yEhL9wCEopmjZtyubNm5k6dSozZ86kWrVqzJo1y+kPAkFBQZw8eZLr168bXcpd/vzzz9vNV1auXCnNV9yIhL9wKEopGjduzKZNm5g+fTqzZ88mICCAmTNncuvWLaPLeyAFChQgKCiIffv2GV3KHXbv3k39+vWl+YqbkvAXDiujneTXX3/N/PnzCQgIYMaMGU55EHC0cf+lS5fSsmVLpkyZwpAhQ2RGjxuS8BcOr1GjRqxfv545c+awaNEiqlSpwvTp07l586bRpeWao8z40Vozbtw4Bg8ezJo1a2jbtq3RJQmDSPgLp9GgQQPWrVvH/PnzWbJkCVWqVGHq1KlOcRBwhDP/mzdv8uKLL/Ltt99K8xUh4S+cT/369VmzZg0LFiwgJiYGPz8/oqOjHfoq2oCAABISEkhKSjJk/xnNVy5cuCDNVwQg4S+cWFhYGKtWrWLx4sV8//33+Pn5MXnyZFJSUowu7S4eHh7Url3bkCmfsbGx1KtXT5qviDtI+AunV7duXVauXMnSpUtZtWoVfn5+/Pe//3W4g4ARQz+bN2+mYcOGDBs2TJqviDtI+AuXUadOHX744QdiYmJYt24dvr6+fP755yQnJxtdGmD/8J89ezbPPfcc8+bNk+Yr4i4S/sLlhISEsGLFCr7//ns2btyIr68vn332meEHAXvN+ElPT+e9997jww8/ZPPmzTRr1szm+xTOR8JfuKzatWsTExPDypUr+fnnn/H19WXChAncuHHDkHoee+wxUlJSOHv2rM32kZycTOfOndm0aRM7d+6kWrVqNtuXcG4S/sLl1apVi2XLlrFq1Sq2b9+Or68vUVFRdr/dglKKkJAQm33o+/fffxMeHk7BggWl+YrIkYS/cBs1a9ZkyZIlrFmzhl27duHr68v48eO5du2a3Wqw1bj/oUOHqFevHq1atZLmKyJXJPyF26lRowaLFy/mp59+Yu/evfj6+jJu3DiuXr1q833bIvxXr15N06ZN+fe//83IkSPlVg0iVyT8hduqXr06ixYtYuPGjfz666/4+vry73//mytXrthsnxkf+mqtrbK9L7744nbzlW7dulllm8I9SPgLtxcYGMiCBQvYvHkzR44cwc/Pj48//tgmB4Fy5crh6enJH3/8kaftpKam8sYbbzBlyhRpviIeiIS/EGbVqlVj/vz5bNmyhePHj+Pr68tHH33E5cuXrbqfvDZ3yWi+cvz4cWm+Ih6YhL8QWQQEBDB37ly2bdtGXFwcfn5+jB49mkuXLlll+3kZ9//zzz956qmnqFChAj/++KM0XxEPTMJfiGxUqVKF2bNns2PHDv744w/8/PwYNWpUnm/O9qDh/8svvxAWFkbv3r2Jjo6W5isiTyT8hciBn58fX3/9Nbt27eLUqVP4+/vzwQcfcPHixQfaXkhICPv27SM9PT3Xr1myZAmtWrUiOjpamq8Iq5DwFyKXfH19mTlzJr/88gtnz56lSpUqvP/++1y4cOG+tlMyNZUR+fNzpV07aNMGuneH8eMhMfGudbXWjB07ljfffJO1a9dK8xVhNRL+Qtynxx9/nBkzZrBnzx4SEhKoUqUK7777LufPn7/3C3fvho4doVIl3rx8meI//AA//ADz50NkJFSsaHrePCR08+ZN+vbty+LFi9m5cydPPvmk7X844TYk/IV4QJUrV2batGns27ePixcvEhAQwPDhw0m0cAZPdDSEh0NMDKSk4JmWdufzycmQkmJ6Pjyc61FRNG/enKSkJLZs2SLNV4TVSfgLkUeVKlXiyy+/ZP/+/Vy5coWqVavy9ttvk5CQYFohOhqGDYMbNyCni7u0hhs3UG+/zesFCrB06VIeeugh2/8Qwu1I+AthJRUrVmTKlCkcOHCA69evU7VqVT7v3h09dKgp+M3+AV4EKgFFgFrAqizb8taaZ7dvx2P/frvVL9xLnsJfKfWcUuqIUipdKRVyj/WeUUr9ppSKU0oNz8s+hXB0FSpUYPLkyRw8eJDwHTtIz9JHIBWoAGwGLgNjgOeBP7JuKDkZxo61fcHCLeX1zP8w0BH4ObsVlFIewGQgAggEuiqlAvO4XyEcXvmCBan5119kbZz4EBAJVMb0H7A18BiwN+sGtIaVKy3OAhIir/IU/lrrY1rr33JYrQ4Qp7U+qbW+CSwE2uVlv0I4hVmzcrXaOeAE8ISlJ5XK9XaEuB/2GPN/FDiV6fvT5mVCuLaDB00zeO7hFvAC0AuoammF5GQ4dMj6tQm3lz+nFZRSPwGPWHjqPa31d9YsRinVD+gHpg/PhHBqOdwQLh3oARQEvrjXinm8nYQQluQY/lrrvHZ/PoPp860M5c3LLO1rGjANICQkxDo3PBfCKMWKZfuUxjTj5xywErjnXXpKlLBqWUKAfYZ9dgP+SqnHlFIFgS7ACjvsVwhj1agB2bRT7A8cA74HvO61DS8vCAqyfm3C7eV1qmcHpdRpIAz4USm1xry8nFJqJYDWOhUYCKzB9O/9W631kbyVLYQT6N3b4uL/A6YCBzCNpxY2P+ZbWlnrbLcjRF7kOOxzL1rr5cByC8v/Alpm+n4lpt9uhXAfPj4QEWG6ZUOmK3srYRr2yZFS0LIllC5tqwqFG5MrfIWwpREjTEM3D8LLy/R6IWxAwl8IWwoNhago8Pa+v9d5e5teF5LthfNC5Emehn2EELnQv7/pz2HDTPP273VzN6VMZ/xRUf97nRA2IGf+QthD//6weTN06GCaAZR1KMjLy7S8QwfTehL8wsbkzF8IewkJgaVLTffqmTXLdOVuUpJpHn9QkGlWj3y4K+xEwl8IeytdGt56y+gqhJuTYR8hhHBDEv5CCOGGJPyFEMINSfgLIYQbkvAXQgg3JOEvhBBuSMJfCCHckIS/EEK4IaXvdZ8RAymlEjHd+tyeSgHn7bxPRyfviWXyvtxN3hPL7P2+VNJa53ipuMOGvxGUUnu01nIbxUzkPbFM3pe7yXtimaO+LzLsI4QQbkjCXwgh3JCE/52mGV2AA5L3xDJ5X+4m74llDvm+yJi/EEK4ITnzF0IIN+TW4a+Uek4pdUQpla6UyvbTeKXUM0qp35RScUqp4fas0d6UUiWVUuuUUrHmP0tks16aUuqA+bHC3nXaS05/90opT6XUIvPzu5RSle1fpX3l4j3prZRKzPTv4yUj6rQnpdRMpVSCUupwNs8rpdQk83t2UClV2941ZuXW4Q8cBjoCP2e3glLKA5gMRACBQFelVKB9yjPEcGC91tofWG/+3pJkrXUt86Ot/cqzn1z+3b8IJGmt/YCJwCf2rdK+7uP/w6JM/z5m2LVIY8wCnrnH8xGAv/nRD4i2Q0335Nbhr7U+prX+LYfV6gBxWuuTWuubwEKgne2rM0w7YLb569lAewNrMVpu/u4zv19LgKZKKWXHGu3N3f4/5IrW+mfg4j1WaQfM0SY7geJKqbL2qc4ytw7/XHoUOJXp+9PmZa6qjNb6rPnrv4Ey2axXSCm1Rym1UynlqgeI3Pzd315Ha50KXAYetkt1xsjt/4dnzcMbS5RSFexTmkNzuBxx+R6+SqmfgEcsPPWe1vo7e9fjCO71nmT+RmutlVLZTQerpLU+o5R6HNiglDqktY63dq3CKX0PLNBa/6OUegXTb0ZNDK5JZOHy4a+1bpbHTZwBMp+5lDcvc1r3ek+UUueUUmW11mfNv5YmZLONM+Y/TyqlNgFPAq4W/rn5u89Y57RSKj9QDLhgn/IMkeN7orXO/PPPAMbboS5H53A5IsM+OdsN+CulHlNKFQS6AC47uwXTz9bL/HUv4K7fjpRSJZRSnuavSwFPAUftVqH95ObvPvP71QnYoF374pkc35MsY9ltgWN2rM9RrQB6mmf91AMuZxpeNYbW2m0fQAdMY2//AOeANebl5YCVmdZrCZzAdGb7ntF12/g9eRjTLJ9Y4CegpHl5CDDD/HV94BDwq/nPF42u24bvx11/98CHQFvz14WAxUAc8AvwuNE1O8B7MhY4Yv73sRGoanTNdnhPFgBngVvmTHkReBV41fy8wjRLKt78fybE6JrlCl8hhHBDMuwjhBBuSMJfCCHckIS/EEK4IQl/IYRwQxL+QgjhhiT8hRDCDUn4CyGEG5LwF0IIN/T/LIKAJVz4GHsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f4925562198>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import networkx as nx\n",
@@ -13,12 +31,12 @@
     "\n",
     "from pyquil.api import get_qc\n",
     "\n",
-    "ideal_qc = get_qc('4q-qvm', noisy=False)\n",
-    "noisy_qc = get_qc(\"4q-noisy-qvm\", noisy=True)\n",
+    "# ideal_qc = get_qc('4q-qvm', noisy=False)\n",
+    "noisy_qc = get_qc(\"Aspen-3-7Q-A\")\n",
     "\n",
-    "qubits = ideal_qc.qubits()\n",
+    "qubits = noisy_qc.qubits()\n",
     "print(qubits)\n",
-    "graph = ideal_qc.qubit_topology()\n",
+    "graph = noisy_qc.qubit_topology()\n",
     "nx.draw_networkx(graph, with_labels=True)"
    ]
   },
@@ -31,17 +49,417 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from forest_benchmarking.quantum_volume import measure_quantum_volume\n",
+    "from forest_benchmarking.quantum_volume import *\n",
     "\n",
     "import logging\n",
     "logger = logging.getLogger()\n",
     "logger.setLevel(logging.INFO)\n",
-    "show_progress_bar = True"
+    "show_progress_bar = True\n",
+    "\n",
+    "from time import time"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "135.61787796020508\n",
+      "0.501314640045166\n",
+      "136.28105354309082\n",
+      "{2: (0.7984, 0.7520739900271997), 3: (0.8514666666666667, 0.8104022973225549)}\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = time()\n",
+    "df = quantum_volume_dataframe(qubits=[1,2,3], num_circuits=300, depths=[2,3])\n",
+    "df = add_circuits_to_dataframe(df)\n",
+    "df, data_acq_time = acquire_qv_data(df, ideal_qc, num_shots=500, use_active_reset=False)\n",
+    "print(data_acq_time)\n",
+    "final_df1, total_sim_time = acquire_heavy_hitters(df)\n",
+    "print(total_sim_time)\n",
+    "end = time()\n",
+    "print(end - start)\n",
+    "\n",
+    "probs_and_errors = get_results_by_depth(final_df1)\n",
+    "print(probs_and_errors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "138.66465878486633\n",
+      "0.5087440013885498\n",
+      "139.33286547660828\n",
+      "{2: (0.5044533333333333, 0.4467205964824244), 3: (0.84524, 0.8034772825916064)}\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = time()\n",
+    "df = quantum_volume_dataframe(qubits=[1,2,3], num_circuits=300, depths=[2,3])\n",
+    "df = add_circuits_to_dataframe(df)\n",
+    "df, data_acq_time = acquire_qv_data(df, noisy_qc, num_shots=500, use_active_reset=True)\n",
+    "print(data_acq_time)\n",
+    "final_df2, total_sim_time = acquire_heavy_hitters(df)\n",
+    "print(total_sim_time)\n",
+    "end = time()\n",
+    "print(end - start)\n",
+    "\n",
+    "probs_and_errors = get_results_by_depth(final_df2)\n",
+    "print(probs_and_errors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = quantum_volume_dataframe(qubits=[1, 2, 3], num_circuits=200, depths=[2,3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = add_circuits_to_dataframe(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "102.20563054084778\n"
+     ]
+    }
+   ],
+   "source": [
+    "df, data_acq_time = acquire_qv_data(df, noisy_qc, num_shots=100, use_active_reset = False)\n",
+    "print(data_acq_time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.11663532257080078\n"
+     ]
+    }
+   ],
+   "source": [
+    "df, total_sim_time = acquire_heavy_hitters(df)\n",
+    "print(total_sim_time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{2: (0.54015, 0.4696676649790886), 3: (0.7777, 0.7188981785996386)}\n"
+     ]
+    }
+   ],
+   "source": [
+    "prob_and_errors = get_results_by_depth(df)\n",
+    "print(prob_and_errors)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "        Qubits  Depth                                            Circuit  \\\n",
+      "0       {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.08354564-0.55237344j...   \n",
+      "1       {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.45098557-0.19330812j...   \n",
+      "2       {1, 2}      2  ([[0, 1], [1, 0]], [[[[ 0.18817431-0.35541579j...   \n",
+      "3       {1, 2}      2  ([[0, 1], [0, 1]], [[[[-0.30056824+0.09468738j...   \n",
+      "4       {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.01248778+0.58819779j...   \n",
+      "5       {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.04556996-0.04822739j...   \n",
+      "6       {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.12018575-0.53868308j...   \n",
+      "7       {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.0343568 -0.20436334j...   \n",
+      "8       {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.42441048+0.28562384j...   \n",
+      "9       {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.21779237-0.33540124j...   \n",
+      "10      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.21324399+0.14784112j...   \n",
+      "11      {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.40989358-0.53365489j...   \n",
+      "12      {1, 2}      2  ([[1, 0], [1, 0]], [[[[-0.56473235+0.31100909j...   \n",
+      "13      {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.11473532+0.70659771j...   \n",
+      "14      {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.384001  -0.23145849j...   \n",
+      "15      {1, 2}      2  ([[0, 1], [1, 0]], [[[[ 0.45945426+0.55874572j...   \n",
+      "16      {1, 2}      2  ([[0, 1], [0, 1]], [[[[ 0.10240352+0.14057013j...   \n",
+      "17      {1, 2}      2  ([[0, 1], [0, 1]], [[[[ 0.27378459+0.39529079j...   \n",
+      "18      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.69048299+0.01094889j...   \n",
+      "19      {1, 2}      2  ([[0, 1], [1, 0]], [[[[-4.62333395e-02-0.34586...   \n",
+      "20      {1, 2}      2  ([[0, 1], [0, 1]], [[[[-0.36045097+0.54366714j...   \n",
+      "21      {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.50184681+0.1789568j ...   \n",
+      "22      {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.24340445+0.54794529j...   \n",
+      "23      {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.09083408-0.52767336j...   \n",
+      "24      {1, 2}      2  ([[0, 1], [0, 1]], [[[[ 0.32536565+0.14520539j...   \n",
+      "25      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.20546105-0.33535614j...   \n",
+      "26      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.29290167+0.10086655j...   \n",
+      "27      {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.09084294-0.52597991j...   \n",
+      "28      {1, 2}      2  ([[1, 0], [1, 0]], [[[[-0.01998412+0.02629819j...   \n",
+      "29      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.20894039-0.65290347j...   \n",
+      "..         ...    ...                                                ...   \n",
+      "370  {1, 2, 3}      3  ([[1, 0, 2], [0, 2, 1], [1, 0, 2]], [[[[-0.230...   \n",
+      "371  {1, 2, 3}      3  ([[1, 2, 0], [0, 1, 2], [2, 1, 0]], [[[[ 0.048...   \n",
+      "372  {1, 2, 3}      3  ([[1, 0, 2], [2, 1, 0], [1, 2, 0]], [[[[-0.039...   \n",
+      "373  {1, 2, 3}      3  ([[2, 1, 0], [2, 1, 0], [1, 0, 2]], [[[[-0.130...   \n",
+      "374  {1, 2, 3}      3  ([[0, 1, 2], [2, 1, 0], [1, 2, 0]], [[[[-0.162...   \n",
+      "375  {1, 2, 3}      3  ([[0, 2, 1], [2, 0, 1], [0, 2, 1]], [[[[-0.267...   \n",
+      "376  {1, 2, 3}      3  ([[1, 0, 2], [1, 0, 2], [1, 0, 2]], [[[[-0.260...   \n",
+      "377  {1, 2, 3}      3  ([[2, 1, 0], [2, 0, 1], [1, 0, 2]], [[[[ 0.120...   \n",
+      "378  {1, 2, 3}      3  ([[1, 2, 0], [2, 1, 0], [2, 0, 1]], [[[[-0.593...   \n",
+      "379  {1, 2, 3}      3  ([[0, 2, 1], [2, 0, 1], [2, 1, 0]], [[[[ 0.357...   \n",
+      "380  {1, 2, 3}      3  ([[2, 1, 0], [1, 2, 0], [0, 1, 2]], [[[[ 0.291...   \n",
+      "381  {1, 2, 3}      3  ([[1, 0, 2], [0, 1, 2], [0, 1, 2]], [[[[ 0.648...   \n",
+      "382  {1, 2, 3}      3  ([[0, 1, 2], [2, 1, 0], [1, 0, 2]], [[[[-0.257...   \n",
+      "383  {1, 2, 3}      3  ([[1, 2, 0], [1, 0, 2], [0, 2, 1]], [[[[-0.138...   \n",
+      "384  {1, 2, 3}      3  ([[1, 0, 2], [2, 0, 1], [0, 2, 1]], [[[[ 0.437...   \n",
+      "385  {1, 2, 3}      3  ([[1, 0, 2], [2, 1, 0], [1, 0, 2]], [[[[ 0.166...   \n",
+      "386  {1, 2, 3}      3  ([[0, 1, 2], [2, 1, 0], [2, 0, 1]], [[[[-0.480...   \n",
+      "387  {1, 2, 3}      3  ([[2, 0, 1], [1, 0, 2], [1, 0, 2]], [[[[ 0.383...   \n",
+      "388  {1, 2, 3}      3  ([[2, 0, 1], [2, 0, 1], [0, 1, 2]], [[[[ 0.028...   \n",
+      "389  {1, 2, 3}      3  ([[0, 2, 1], [0, 2, 1], [2, 1, 0]], [[[[-0.172...   \n",
+      "390  {1, 2, 3}      3  ([[0, 2, 1], [2, 0, 1], [2, 1, 0]], [[[[ 0.173...   \n",
+      "391  {1, 2, 3}      3  ([[0, 1, 2], [2, 0, 1], [2, 0, 1]], [[[[ 0.436...   \n",
+      "392  {1, 2, 3}      3  ([[2, 1, 0], [2, 1, 0], [2, 0, 1]], [[[[ 0.614...   \n",
+      "393  {1, 2, 3}      3  ([[1, 2, 0], [1, 0, 2], [0, 2, 1]], [[[[ 0.455...   \n",
+      "394  {1, 2, 3}      3  ([[2, 0, 1], [1, 2, 0], [1, 2, 0]], [[[[ 0.239...   \n",
+      "395  {1, 2, 3}      3  ([[2, 0, 1], [1, 2, 0], [2, 0, 1]], [[[[ 0.387...   \n",
+      "396  {1, 2, 3}      3  ([[1, 2, 0], [2, 0, 1], [2, 1, 0]], [[[[-0.071...   \n",
+      "397  {1, 2, 3}      3  ([[0, 1, 2], [0, 2, 1], [0, 1, 2]], [[[[-0.236...   \n",
+      "398  {1, 2, 3}      3  ([[1, 0, 2], [0, 2, 1], [2, 0, 1]], [[[[ 0.131...   \n",
+      "399  {1, 2, 3}      3  ([[1, 0, 2], [0, 1, 2], [1, 2, 0]], [[[[-0.583...   \n",
+      "\n",
+      "                                               Results   RunTime  \\\n",
+      "0    [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0], [0, 1...  0.291788   \n",
+      "1    [[0, 1], [0, 1], [0, 1], [1, 0], [1, 1], [0, 1...  0.181660   \n",
+      "2    [[1, 1], [1, 1], [0, 0], [1, 0], [1, 0], [1, 1...  0.180506   \n",
+      "3    [[1, 0], [1, 0], [1, 0], [1, 0], [1, 0], [1, 1...  0.177028   \n",
+      "4    [[0, 0], [0, 0], [1, 0], [1, 1], [0, 1], [1, 0...  0.179637   \n",
+      "5    [[0, 0], [0, 0], [0, 0], [1, 1], [0, 1], [0, 1...  0.191679   \n",
+      "6    [[1, 1], [0, 0], [0, 1], [0, 0], [0, 0], [1, 1...  0.250205   \n",
+      "7    [[0, 0], [1, 0], [1, 0], [0, 1], [0, 0], [0, 0...  0.183192   \n",
+      "8    [[0, 1], [0, 1], [1, 1], [1, 1], [0, 1], [0, 1...  0.190195   \n",
+      "9    [[0, 1], [0, 0], [1, 0], [0, 1], [1, 1], [0, 0...  0.178466   \n",
+      "10   [[0, 0], [1, 1], [1, 1], [1, 0], [0, 0], [0, 0...  0.178089   \n",
+      "11   [[0, 0], [0, 1], [0, 0], [1, 0], [0, 0], [1, 1...  0.182206   \n",
+      "12   [[0, 0], [0, 0], [1, 1], [0, 0], [0, 0], [1, 1...  0.175373   \n",
+      "13   [[0, 0], [1, 1], [0, 0], [1, 0], [0, 1], [0, 1...  0.185450   \n",
+      "14   [[0, 0], [1, 0], [1, 0], [1, 0], [1, 0], [1, 0...  0.193900   \n",
+      "15   [[1, 0], [0, 0], [0, 0], [1, 0], [1, 0], [0, 0...  0.237631   \n",
+      "16   [[1, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0...  0.202537   \n",
+      "17   [[0, 0], [1, 0], [1, 0], [1, 0], [1, 0], [1, 1...  0.180199   \n",
+      "18   [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0...  0.186573   \n",
+      "19   [[1, 1], [1, 0], [0, 1], [0, 1], [0, 1], [1, 1...  0.186149   \n",
+      "20   [[0, 1], [1, 1], [0, 1], [0, 1], [1, 0], [1, 1...  0.187587   \n",
+      "21   [[1, 1], [1, 0], [1, 0], [1, 0], [1, 1], [1, 1...  0.185353   \n",
+      "22   [[0, 1], [0, 0], [1, 1], [0, 1], [0, 1], [0, 1...  0.177998   \n",
+      "23   [[1, 0], [0, 1], [1, 0], [0, 1], [1, 0], [0, 0...  0.178340   \n",
+      "24   [[0, 0], [1, 0], [1, 0], [1, 0], [1, 0], [0, 0...  0.251029   \n",
+      "25   [[0, 0], [0, 0], [1, 1], [1, 1], [1, 0], [0, 0...  0.186509   \n",
+      "26   [[0, 0], [0, 1], [0, 1], [1, 0], [1, 0], [0, 1...  0.180358   \n",
+      "27   [[0, 0], [1, 0], [0, 1], [1, 0], [1, 0], [1, 0...  0.193331   \n",
+      "28   [[1, 0], [1, 0], [1, 0], [0, 0], [1, 0], [0, 0...  0.180303   \n",
+      "29   [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0...  0.185431   \n",
+      "..                                                 ...       ...   \n",
+      "370  [[0, 0, 1], [0, 0, 0], [0, 0, 0], [1, 0, 0], [...  0.335995   \n",
+      "371  [[1, 0, 0], [0, 0, 1], [1, 1, 1], [1, 1, 0], [...  0.339910   \n",
+      "372  [[1, 1, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0], [...  0.336974   \n",
+      "373  [[0, 1, 0], [0, 1, 1], [0, 1, 1], [0, 0, 0], [...  0.263358   \n",
+      "374  [[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0], [...  0.263503   \n",
+      "375  [[0, 0, 1], [1, 0, 0], [0, 0, 0], [0, 0, 0], [...  0.209372   \n",
+      "376  [[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0], [...  0.207757   \n",
+      "377  [[1, 0, 1], [0, 0, 0], [1, 1, 0], [0, 1, 1], [...  0.393412   \n",
+      "378  [[1, 0, 0], [1, 1, 1], [1, 0, 1], [0, 1, 0], [...  0.256955   \n",
+      "379  [[0, 1, 0], [0, 0, 0], [1, 1, 1], [1, 1, 1], [...  0.257491   \n",
+      "380  [[1, 0, 0], [1, 0, 0], [0, 0, 0], [1, 0, 0], [...  0.263339   \n",
+      "381  [[1, 1, 0], [0, 0, 0], [0, 0, 0], [1, 1, 0], [...  0.218792   \n",
+      "382  [[0, 0, 1], [0, 1, 1], [0, 0, 1], [1, 1, 1], [...  0.398403   \n",
+      "383  [[1, 0, 0], [0, 1, 1], [1, 0, 0], [0, 0, 1], [...  0.339747   \n",
+      "384  [[0, 0, 1], [0, 0, 0], [0, 0, 0], [1, 0, 0], [...  0.257747   \n",
+      "385  [[0, 0, 1], [0, 0, 1], [1, 0, 1], [1, 0, 1], [...  0.334514   \n",
+      "386  [[1, 0, 1], [0, 0, 0], [1, 0, 0], [0, 1, 0], [...  0.408417   \n",
+      "387  [[0, 0, 1], [0, 1, 0], [1, 0, 1], [1, 0, 1], [...  0.262085   \n",
+      "388  [[0, 0, 1], [1, 1, 0], [1, 0, 0], [0, 0, 1], [...  0.258457   \n",
+      "389  [[0, 0, 1], [1, 1, 1], [1, 0, 0], [0, 0, 0], [...  0.258218   \n",
+      "390  [[1, 0, 1], [0, 0, 0], [0, 1, 1], [0, 0, 0], [...  0.333805   \n",
+      "391  [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 1, 1], [...  0.254135   \n",
+      "392  [[0, 0, 0], [1, 0, 1], [1, 0, 0], [1, 1, 1], [...  0.265176   \n",
+      "393  [[1, 0, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0], [...  0.345715   \n",
+      "394  [[1, 0, 1], [0, 1, 0], [0, 1, 1], [1, 1, 0], [...  0.328683   \n",
+      "395  [[0, 1, 0], [1, 0, 1], [1, 1, 1], [1, 0, 0], [...  0.341782   \n",
+      "396  [[1, 0, 1], [0, 0, 0], [0, 0, 0], [1, 0, 1], [...  0.346028   \n",
+      "397  [[0, 1, 1], [0, 1, 1], [0, 0, 1], [0, 0, 1], [...  0.334668   \n",
+      "398  [[0, 1, 1], [1, 0, 1], [0, 0, 1], [0, 0, 1], [...  0.326390   \n",
+      "399  [[1, 1, 1], [0, 0, 1], [1, 0, 1], [0, 1, 0], [...  0.271829   \n",
+      "\n",
+      "     HeavyHitters   SimTime  NumHHSampled  \n",
+      "0    [0, 2, 4, 6]  0.000490            58  \n",
+      "1    [0, 2, 4, 6]  0.000204             9  \n",
+      "2    [0, 2, 4, 6]  0.000164            56  \n",
+      "3    [0, 2, 4, 6]  0.000153            74  \n",
+      "4    [0, 2, 4, 6]  0.000189            87  \n",
+      "5    [0, 2, 4, 6]  0.000180            71  \n",
+      "6    [0, 2, 4, 6]  0.000220            66  \n",
+      "7    [0, 2, 4, 6]  0.000212            61  \n",
+      "8    [0, 2, 4, 6]  0.000268            18  \n",
+      "9    [0, 2, 4, 6]  0.000309            65  \n",
+      "10   [0, 2, 4, 6]  0.000788            48  \n",
+      "11   [0, 2, 4, 6]  0.000212            59  \n",
+      "12   [0, 2, 4, 6]  0.000213            40  \n",
+      "13   [0, 2, 4, 6]  0.000188            46  \n",
+      "14   [0, 2, 4, 6]  0.000189            92  \n",
+      "15   [0, 2, 4, 6]  0.000207            85  \n",
+      "16   [0, 2, 4, 6]  0.000196            58  \n",
+      "17   [0, 2, 4, 6]  0.000184            48  \n",
+      "18   [0, 2, 4, 6]  0.000189            87  \n",
+      "19   [0, 2, 4, 6]  0.000324            32  \n",
+      "20   [0, 2, 4, 6]  0.000194            13  \n",
+      "21   [0, 2, 4, 6]  0.000194            63  \n",
+      "22   [0, 2, 4, 6]  0.000204            50  \n",
+      "23   [0, 2, 4, 6]  0.000238            41  \n",
+      "24   [0, 2, 4, 6]  0.000196            85  \n",
+      "25   [0, 2, 4, 6]  0.000204            59  \n",
+      "26   [0, 2, 4, 6]  0.000153            40  \n",
+      "27   [0, 2, 4, 6]  0.000118            81  \n",
+      "28   [0, 2, 4, 6]  0.000135            83  \n",
+      "29   [0, 2, 4, 6]  0.000189            74  \n",
+      "..            ...       ...           ...  \n",
+      "370  [0, 5, 6, 7]  0.000142            61  \n",
+      "371  [1, 4, 6, 7]  0.000145            83  \n",
+      "372  [2, 4, 6, 7]  0.000144            88  \n",
+      "373  [2, 3, 4, 6]  0.000145            63  \n",
+      "374  [0, 3, 4, 7]  0.000147            78  \n",
+      "375  [0, 1, 4, 5]  0.000145            97  \n",
+      "376  [0, 2, 4, 6]  0.000142            98  \n",
+      "377  [0, 4, 5, 6]  0.000153            83  \n",
+      "378  [2, 3, 5, 7]  0.000146            75  \n",
+      "379  [0, 1, 3, 7]  0.000146            82  \n",
+      "380  [0, 2, 4, 6]  0.000144            94  \n",
+      "381  [0, 2, 4, 6]  0.000144            98  \n",
+      "382  [1, 2, 4, 7]  0.000144            74  \n",
+      "383  [1, 3, 4, 5]  0.000144            74  \n",
+      "384  [0, 2, 4, 5]  0.000146            81  \n",
+      "385  [1, 3, 5, 7]  0.000146            82  \n",
+      "386  [0, 2, 6, 7]  0.000146            77  \n",
+      "387  [0, 2, 3, 5]  0.000143            79  \n",
+      "388  [0, 2, 4, 6]  0.000156            87  \n",
+      "389  [1, 3, 4, 7]  0.000147            73  \n",
+      "390  [0, 1, 3, 4]  0.000147            87  \n",
+      "391  [0, 2, 3, 4]  0.000144            86  \n",
+      "392  [1, 4, 5, 7]  0.000146            81  \n",
+      "393  [0, 1, 2, 5]  0.000145            78  \n",
+      "394  [1, 2, 3, 5]  0.000157            68  \n",
+      "395  [3, 4, 5, 7]  0.000145            72  \n",
+      "396  [0, 4, 5, 6]  0.000147            73  \n",
+      "397  [1, 2, 3, 4]  0.000148            74  \n",
+      "398  [1, 2, 5, 7]  0.000146            73  \n",
+      "399  [1, 4, 6, 7]  0.000144            76  \n",
+      "\n",
+      "[400 rows x 8 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -59,11 +477,45 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 200/200 [00:39<00:00,  5.13it/s]\n",
+      "100%|██████████| 200/200 [00:59<00:00,  3.36it/s]\n",
+      "100%|██████████| 200/200 [02:57<00:00,  1.13it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[(2, 0.794665, 0.7375383796247318, True), (3, 0.848665, 0.7979831062360531, True), (4, 0.841005, 0.7892912513493752, True)]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "ideal_outcomes = measure_quantum_volume(ideal_qc, num_circuits=200, show_progress_bar=show_progress_bar)\n",
+    "print(ideal_outcomes)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ideal_outcomes = measure_quantum_volume(ideal_qc, num_circuits=200, show_progress_bar=show_progress_bar)"
+    "ideal_outcomes = [(2, 0.794665, 0.7375383796247318, True), (3, 0.848665, 0.7979831062360531, True), (4, 0.841005, 0.7892912513493752, True)]"
    ]
   },
   {
@@ -218,9 +670,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/examples/quantum_volume.ipynb
+++ b/examples/quantum_volume.ipynb
@@ -2,27 +2,9 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0, 1, 2, 3]\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX8AAAD8CAYAAACfF6SlAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMS4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvpW3flQAAIABJREFUeJzt3XlcVGX7x/HPLSpC7immuRUgSqImoGLqg0sa7prlkntlaZamVtqiWPZoPqTlk5JL5pqaG1m55pZ7rrknYP1SM0HFHVLg/v0xgw/iICgzc2a53q/XvIQzZ865GPV7Dvfc51xKa40QQgj3ks/oAoQQQtifhL8QQrghCX8hhHBDEv5CCOGGJPyFEMINSfgLIYQbkvAXQgg3JOEvhBBuSMJfCCHcUH6jC8hOqVKldOXKlY0uQwghnMrevXvPa61L57Sew4Z/5cqV2bNnj9FlCCGEU1FK/V9u1pNhHyGEcEMS/kII4YYk/IUQwg1J+AshhBuS8BdCCDck4S+EEG5Iwl8IIdyQhL8QQrghh73ISwirSEiAWbPg4EG4fBmKFYMaNaBPHyid40WQQrgsCX/hmnbvhrFjYdUq0/cpKf97btkyGDUKIiJgxAgIDTWmRiEMJMM+wvVER0N4OMTEmEI/c/ADJCeblsXEmNaLjjaiSiEMJWf+wrVER8OwYXDjRs7ram1ab9gw0/f9+9u2NiEciJz5C9exe7fF4O8OlAWKAlWAGVlfl3EAkBsJCjci4S9cx9ixpiGdLEYAfwBXgBXA+8DerCslJ5teL4SbsEr4K6VmKqUSlFKHs3leKaUmKaXilFIHlVK1rbFfIW5LSDB9uKv1XU89AXiav1bmR3zWlbSGlSshMdGmZQrhKKx15j8LeOYez0cA/uZHP0A+YRPWNWvWPZ8eAHgDVTENAbW0tJJSOW5HCFdhlfDXWv8MXLzHKu2AOdpkJ1BcKVXWGvsWAjDN4886qyeTKcBVYAvQkf/9JnCH5GQ4dMgm5QnhaOw15v8ocCrT96fNy+6glOqnlNqjlNqTKL9+i/tx+XKOq3gADTD948v2V8+kJOvVJIQDc6gPfLXW07TWIVrrkNJy9aW4H8WK5XrVVCyM+WcoUcIa1Qjh8OwV/meACpm+L29eJoR11KgBhQrdtTgBWAhcA9KANcACoKmlbXh5QVCQDYsUwnHYK/xXAD3Ns37qAZe11mfttG/hDnr3trhYYRriKQ+UAIYBnwFtLayblpaG7tXLRgUK4VisNdVzAbADCFBKnVZKvaiUelUp9ap5lZXASSAOmI5p8oUQ1uPjAxERaKXuWFwa2AxcwjTP/xDwsoWXpyvF+oIFadChA2vXrkVbmDIqhCuxyu0dtNZdc3heA69ZY19CZOefIUNgxQo809Lu+7X5vLxo+tNPnI+PZ9CgQRQvXpzIyEiaN2+OynJAEcIVONQHvkI8qMTERJq88w5zatRAe3vf34u9vSEqCo+6denWrRuHDx9m0KBBDBkyhLCwMFatWiW/CQiXI+EvnN6xY8eoV68e4eHhvLhnDyoqyhToOZ2xK3U7+DPf1M3Dw4MuXbpw6NAhhgwZwltvvUXdunX58ccf5SAgXIfW2iEfwcHBWoicrFu3Tvv4+OhZs2bd+cTu3Vp37Kh1oUJae3lpbbqBg9ag/8mf37S8Y0fTejlIS0vTixcv1kFBQTokJESvWLFCp6en2+gnEiJvgD06FxmrtIOeyYSEhOg9cpdFcQ/Tpk1j5MiRLFq0iH/961+WV0pMNN2y4dAhSEri9PXrrDx1in7bt993J6/09HRiYmL48MMP8fDwYOTIkbRt21Y+ExAORSm1V2sdkuN6Ev7C2aSlpfHOO++wYsUKfvzxR/z9/XP92oSEBAICArh48eIDh3Z6ejorVqxg9OjRAIwcOZJ27dqRL5+Mogrj5Tb85V+rcCrXr1/n2WefZc+ePezcufO+gh/Ax8eHokWLEhcX98A15MuXj/bt27Nv3z5Gjx7NRx99xJNPPsnSpUtJT09/4O0KYU8S/sJpnDlzhoYNG1KyZEnWrl1LyZIlH2g7oaGhWOO3SqUUbdu2Ze/evYwZM4axY8dSq1YtlixZIgcB4fAk/IVT2L9/P/Xq1eP555/nq6++omDBgg+8rdDQUHbv3m212pRStGnTht27dzN27FjGjx9PzZo1+fbbb+UgIByWhL9weCtWrKB58+ZMnDiR4cOH5/kDVmuHfwalFK1atWLXrl2MHz+eCRMmEBQUxMKFC0l7gAvPhLAlCX/hsLTWfPrpp/Tv358ff/yRTp06WWW7wcHBHDhwgNTUVKtsLyulFBEREezYsYMJEyYwadIkqlevzjfffCMHAeEwJPyFQ7p16xavvvoqs2fPZseOHdSpU8dq2y5WrBjlypXj2LFjVtumJUopWrRowbZt25g0aRJTpkzhiSeeYN68eTY78AiRWxL+wuFcunSJli1bcvr0abZt20bFihWtvg9bDf1YopTi6aefZsuWLUyePJlp06YRGBjInDlz5CAgDCPhLxzKyZMnqV+/PoGBgXz33XcUKVLEJvux1oyf+6GUomnTpmzevJmpU6fy1VdfUa1aNWbPni0HAWF3Ev7CYWzbto2nnnqKAQMG8Pnnn5M/v1VuOmuRPc/8s1JK0bhxYzZv3sz06dOZNWsWVatW5euvv+bWrVuG1CTcj4S/cAjffPMNHTp0YObMmQwcONDm+6tVqxZHjx7ln3/+sfm+7iU8PJyNGzcyc+ZM5s2bR0BAAF999ZUcBITNSfgLQ2mtGT16NO+++y4bNmwgIiLCLvv19vbG39+fgwcP2mV/OWnUqBHr169nzpw5LFy4kCpVqjB9+nRu3rxpdGnCRUn4C8OkpKTQvXt3Vq5cyc6dO6levbpd9x8SEmLY0E92GjRowLp165g3bx6LFy+mSpUqTJ06VQ4Cwuok/IUhEhMTadq0Kbdu3WLTpk088sgjdq/ByHH/nDz11FOsXbuWBQsWsHz5cvz9/YmOjjZ8mEq4Dgl/YXdHjx6lbt26NG7cmIULF+Ll5WVIHUbM+LlfYWFhrF69mm+//Zbvv/8ePz8/pkyZIgcBkWcS/sKufvrpJ8LDwxk1ahRjxowx9DbIQUFBnDx5kuvXrxtWQ27VrVuXlStXsnTpUlauXImfnx9ffPEFKSkpRpcmnJSEv7CbadOm0b17d5YsWUKvXr2MLocCBQoQFBTEvn37jC4l1+rUqcMPP/zA8uXLWbt2LX5+fkyaNInk5GSjSxNORsJf2FxaWhrDhg3j008/ZcuWLTRq1Mjokm5zxA99cyMkJIQVK1awYsUKNmzYgJ+fH5999pkcBESuSfgLm7p27RodO3Zk79697Nix476br9iaI3/omxu1a9cmJiaGH3/8kZ9//hlfX18mTJjAjRs3jC5NODgJf2Ezp0+fpmHDhjz88MOsWbPmgZuv2JIzfOibG7Vq1WLZsmWsWrWKbdu24evrS1RUlFN8niGMIeEvbGLfvn2EhYXRuXPnPDdfsaWAgADOnTtHUlKS0aVYRc2aNVm6dClr1qxh165d+Pr6Mn78eK5du2Z0acLBSPgLq/vuu+9o0aIFn332mVWar9iSh4cHtWvXdomz/8xq1KjB4sWL+emnn9i7dy++vr588sknchAQt0n4C6vJaL4yYMAAVq5cybPPPmt0Sbni7OP+91K9enUWLVrEhg0bOHDgAL6+vowdO5arV68aXZowmIS/sIpbt27xyiuv3G6+EhoaanRJueasM37uxxNPPMGCBQvYtGkThw8fxtfXl48//pgrV64YXZowiIS/yLNLly4RERHBX3/9ZbPmK7bkymf+WVWrVo358+ezZcsWjh8/jq+vLx999BGXL182ujRhZxL+Ik9OnjxJWFgY1atXt2nzFVt67LHHSElJ4ezZs0aXYjcBAQHMnTuXbdu2ERsbi5+fH6NHj+bSpUtGlybsRMJfPLCM5isDBw7ks88+w8PDw+iSHohSipCQEJf70Dc3qlSpwpw5c9i+fTu///47fn5+REZGuszsJ5E9CX/xQObPn0+HDh34+uuvee2114wuJ8/caejHEn9/f2bNmsWuXbv4888/8ff3Z+TIkVy8eNHo0oSNSPiL+6K1JjIykvfee48NGzbwzDPPGF2SVbh7+Gfw9fVl5syZ/PLLL/z1119UqVKF999/nwsXLhhdmrAyCX+RaykpKbzwwgusXr3akOYrtpQx40drbXQpDuHxxx9nxowZ7N69m4SEBKpUqcK7777L+fPnjS5NWImEv8iVjOYraWlpbNy40ZDmK7ZUrlw5PD09+eOPP4wuxaE89thjTJs2jX379nHx4kUCAgIYPnw4iYmJRpcm8sgq4a+UekYp9ZtSKk4pNdzC872VUolKqQPmx0vW2K+wj4zmK02aNGHBggWGNV+xNVe5z48tVKpUiS+//JL9+/dz5coVqlatyjvvvCMHASeW5/BXSnkAk4EIIBDoqpQKtLDqIq11LfNjRl73K+xj3bp1hIeHExkZyUcffWRo8xVbk3H/nFWsWJEpU6Zw4MABrl27RtWqVXnrrbc4d+6c0aWJ+2SN/8l1gDit9Umt9U1gIdDOCtsVBps6dSo9evRgyZIl9OzZ0+hybE7CP/cqVKjA5MmT+fXXX0lJSaFatWoMHTqUv//+2+jSRC5ZI/wfBU5l+v60eVlWzyqlDiqlliilKlhhv8JG0tLSGDp0KBMmTHC45iu2FBISwr59+0hPTze6FKdRvnx5/vvf/3L48GFSU1MJDAzkzTffdKsL5pyVvX6H/x6orLWuAawDZltaSSnVTym1Rym1R8YSjZHRfGX//v0O2XzFlkqWLEmpUqX47bffjC7F6ZQrV47PP/+cI0eOAKZ7CQ0aNIi//vrL4MpEdqwR/meAzGfy5c3LbtNaX9Ba/2P+dgYQbGlDWutpWusQrXVI6dKlrVCauB8ZzVdKlSrF6tWrHbL5iq3J0E/elC1blokTJ3L06FHy589P9erVef311zlz5kzOLxZ2ZY3w3w34K6UeU0oVBLoAKzKvoJQqm+nbtsAxK+xXWNHevXupV68eXbp0YcaMGQ7bfMXWZMaPdTzyyCN8+umnHDt2DE9PT4KCgnjttdc4depUzi8WdpHn8NdapwIDgTWYQv1brfURpdSHSqm25tXeUEodUUr9CrwB9M7rfoX1xMTE8Mwzz/D555/zzjvvOHTzFVuTM3/rKlOmDFFRURw/fpyHHnqIWrVqMWDAAP7880+jS3N7ylGvaAwJCdFyBmZbWmsmTJjAxIkTiYmJISQkxOiSDHft2jXKlCnDpUuXKFCggNHluJzExEQ+/fRTpk+fznPPPceIESOoVKmS0WW5FKXUXq11jv+ZXXfStrinjOYrc+bMYceOHRL8ZoULF6Zy5cocPnzY6FJcUunSpRk3bhy//fYbJUuWpHbt2vTr10+urDaAhL8bSkpKut18ZevWrVSoIDNvM5OhH9srVaoU//73vzlx4gQ+Pj4EBwfz0ksvcfLkSaNLcxsS/m4mPj6e+vXrO3XzFVuTD33t5+GHH2bMmDHExsZSrlw56tSpQ9++fYmPjze6NJcn4e9Gtm3bRoMGDXj99deduvmKrcmZv/2VLFmSDz/8kNjYWCpWrEjdunXp06cPcXFxRpfmsiT83UTm5isDBgwwuhyHVrNmTU6cOEFycrLRpbidEiVKEBkZSVxcHJUrVyYsLIxevXoRGxtrdGkuR8LfxWmtGTVqFO+//75LNV+xJU9PT6pVq8aBAweMLsVtFS9enFGjRhEXF4efnx/169enR48ecvW1FUn4u7CM5itr1qxxueYrtpbR3EUYq1ixYnzwwQfEx8dTtWpVGjZsyAsvvMDx48eNLs3pSfi7qISEBJo0aXK7+UqZMmWMLsmpyLi/YylatCjvvfce8fHxVK9enUaNGtG1a1eOHj1qdGlOS8LfBR09epR69erRtGlTl26+Yksy48cxFSlShBEjRhAfH0/NmjVp3LgxnTt3lusyHoCEv4txp+YrthQYGMjp06e5cuWK0aUIC4oUKcLw4cOJj48nODiYZs2a8fzzz3Po0CGjS3Makgwu5Msvv3Sr5iu2lD9/fmrWrMnevXuNLkXcQ+HChXn77beJj4+nTp06NG/enE6dOnHw4EGjS3N4Ev4uIC0tjSFDhjBx4kS2bt3qNs1XbE3G/Z3HQw89xLBhw25fxNiiRQs6duwoM7buQcLfyV27do0OHTpw4MABduzYgZ+fn9EluQyZ8eN8vL29GTJkCPHx8TRq1IiWLVvSvn179u/fb3RpDkfC34llNF/x8fFx2+YrtiRn/s7L29ubwYMHEx8fT5MmTWjdujVt27aVYbxMJPydVEbzla5duzJ9+nS3bb5iS35+fly6dAlpKeq8vLy8eOONN4iPj6d58+a0a9eO1q1by0EdCX+nlNF8ZdKkSbz99ttu3XzFlvLly0dISIhM+XQBhQoVYuDAgcTFxREREUHHjh1p2bIlu3btMro0w0j4OxGtNVFRUbz22musWrWKjh07Gl2Sy5OhH9dSqFAhXnvtNeLi4mjTpg3PPfccERER7Ny50+jS7E7C30ncunWLfv36MW/ePHbu3CnNV+xEwt81eXp60r9/f2JjY2nfvj2dO3emRYsWbN++3ejS7EbC3wlkNF85e/YsW7ZskeYrdpQx48dR252KvPH09OSVV14hNjaWTp068cILL/D000+zdetWo0uzOQl/B5cxbzkoKEiarxigQoUKaK05ffq00aUIGypYsCAvv/wyJ06coEuXLvTs2ZOmTZvy888/3//GEhJg/Hjo3h3atDH9OX48ONrEAa21Qz6Cg4O1u9uyZYsuU6aMnjx5stGluLVWrVrpZcuWGV2GsKObN2/qmTNnal9fXx0eHq43btyY84t++UXrDh20LlTI9ID/Pby8TMs6dDCtZ0PAHp2LjJUzfwc1b948OnbsyOzZs6X5isFk3N/9FChQgD59+nD8+HF69+7NSy+9RHh4OBs3brQ8BBgdDeHhEBMDKSmmR2bJyaZlMTGm9aKj7fFj3JOEv4PR5uYrH3zwARs3bqRFixZGl+T2JPzdV/78+enVqxfHjx+nb9++vPLKK/zrX/9i/fr1/zsIREfDsGFw44bpPP9etDatN2yY4QcAZfEo5gBCQkK0u82vTklJoW/fvvz+++/ExMTIPfgdREJCAgEBAVy8eFGuqXBzqampLFy4kDFjxlCqVCk+7dKFOu+8g7px4471LgIvAmuBUsBYoFvWjXl7w+bNYOWZe0qpvVrrHDcqZ/4OIqP5Snp6Ohs2bJDgdyA+Pj4ULVpUmokL8ufPT/fu3Tly5AgDBgzgyogRpGcJfoDXgILAOWA+0B84knWl5GQYO9bWJWdLwt8BHDlyhLp169K0aVO++eYbab7igKS5i8jMw8ODbs2a0Sw1FY8sz10HlgIfAYWBBkBbYG7WjWgNK1caNgtIwt9ga9eupXHjxnz44YfSfMWBybi/uMusWVgaBDwB5AeqZFpWEwtn/gBKwaxZ1q8tFyRpDPTll1/Ss2dPli5dSo8ePYwuR9yDhL+4y8GDd8/qAa4BRbMsKwZctbSN5GQwqPtYfkP26ubS0tIYNmwYq1atYuvWrXIPficQHBzMgQMHSE1NJX9++W/jLpKTk0lISLj9OHfu3O2vu2/aRG0LrykMZG3+eQXI9vLMpCRrlpxr8q/Yzq5du0bXrl25fv06O3bsoESJEkaXJHKhWLFilCtXjmPHjhEUFGR0OeIBpaWlcfHixbuCPLuAv3XrFj4+Pnc8ypQpw6OPPkrxSpXgzJm79lEFSAViAX/zsl+BJ7IryqAMkPC3o9OnT9OmTRuCg4OZMmWK3IPfyWQM/Uj4O5Zr165ZDHFLAX/x4kWKFSt2O8Qzh3pwcPAdAe/j40ORIkWyn96blgb79t019PMQ0BEYCcwADgDfARZvGeflBQb9e5Lwt5O9e/fSrl07Bg0axLBhw2S+uBPKmPHTt29fo0txaampqZw/f/6eIZ75obW+K8h9fHyoVKkSderUuWNZqVKlrDds17s3jBpl8akpQF/AB3gYiCabM3+tTdsxgIS/HcTExPDyyy8zbdo0OnToYHQ54gGFhoYyb948o8twOlprrl69mqsgP3fuHJcvX6ZkyZJ3DbX4+Pjg6+t7V8gXLlzYmB/MxwciItAxMagsF8uWBGJyer1S0LIllC5tqwrvScLfhrS5+crnn3/OqlWr5B78Tq5WrVocPXqUf/75B09PT6PLMdTNmzdJTEzM9XBLgQIF7gpyHx8f/P39eeqpp+54rmTJknh4ZJ0975jO9e1L0ZgYHujKHC8vGDHC2iXlmoS/jdy6dYsBAwawe/duduzYIffgdwHe3t74+/tz8OBBQkNDjS7HqrTWXLp0KVdBnpCQwNWrVylduvRdZ+E+Pj4EBATcEfClS5fG29vb6B/R6vbu3Uu7V19lZvv2PL1mzV23eLgnb2+IirL6rR3uh4S/DSQlJdGpUye8vb3ZsmWL3IPfhWQ0d3GG8E9JSbnj7Pxewy2JiYl4eXlZDPMnnniCxo0b37GsRIkSbn1B4vLly+nXrx/Tpk2jeYcO/7u5W3LyvW/uppTpjD8qCvr3t1/BFlgl/JVSzwCfAx7ADK31uCzPewJzgGDgAtBZa/2HNfbtaOLj42nVqhURERFERUU5za+vIndCQ0MN6/eanp5OUlJSjmPmGV8nJydbHDcvU6YMQUFBd4W8uw9l5UbmodzVq1cTHBxseqJ/fwgNNd2rZ+VKU8gnJ//vhV5epoNCy5amoR4HGALOc/grpTyAycDTwGlgt1Jqhdb6aKbVXgSStNZ+SqkuwCdA57zu29Fs3bqVTp06MWrUKPobfFQXthEaGsoXX3xhte3duHEj10Mt58+fp0iRIhanKdasWfOu5cWKFZNZZVaUeSh3586dlC9f/s4VQkJg6VLTvXpmzTJduZuUZJrHHxRkmtVj0Ie7lljjzL8OEKe1PgmglFoItAMyh387INL89RLgC6WU0o56P+kHMG/ePIYMGcLcuXPlHvwuLCgoiJMnT3L9+nUeeuihu55PS0vjwoULuZqmeO7cOVJTUy1OUyxfvvwd884zpinKtSHGyDyUu3Xr1nvPMCpdGt56y37FPSBrhP+jwKlM358G6ma3jtY6VSl1GdP01/NW2L+hMpqvzJ07l40bN/LEE9lexyeckNaa69ev3xHiZcqUYfDgwXh7e98V8ElJSRQvXtzicEtoaOhdIX/Pi4iEQ8gYym3ZsiX/+c9/XGYo16E+8FVK9QP6AVSsWNHganKWkpJCnz59+OOPP9i5c6fcg99JpKamZjtN0dJZOnDHeLmXlxe///47rVu3pm7duneE/MMPPyz3/nEhW7Zs4bnnniMyMpJXX33V6HKsyhr/Ss8Amecxljcvs7TOaaVUfkw3ubuQdUNa62nANDB18rJCbTaTkJBA+/btqVixIhs2bJB78BtIa82VK1dyFeQJCQlcvnyZhx9+2OLMFl9f37uGYbIO78yePZvVq1czePBgg35iYQ8ZQ7nz5s2jefPmRpdjddYI/92Av1LqMUwh34W7O5atAHoBO4BOwAZnHu8/cuQIrVu3pkePHkRGRrr1lDdbyXwRUW5mt3h6elq8AVdAQAANGza8Y3leLyIKDQ3lo48+suJPKxyJuwzl5jn8zWP4A4E1mKZ6ztRaH1FKfQjs0VqvAL4C5iql4jC1t+yS1/1aVUKC6dP5gwfh8mUoVgxq1IA+fe76dH7NmjX06NGDTz/9VO7Bfx8yLiLK7TTFa9eu3b6IKOuZeLVq1e4I+NKlS9v1N6+AgIDb4/tyV1bXkjGU+3//93/s2rULHx8fo0uyGfdu4L57t2le7qpVpu8z350vY15uRIRpXm5oKNHR0YwePZrFixfTsGFD29bmBFJSUnI9bp6YmIi3t7fFmS2WLvsvXry4Q/9GFR4eznvvvcfTTz9tdCnCSs6dO0f79u2pXLkyX3/9NYUKFTK6pAeS2wbu7vvJVE5X5GVcoBETg16zhiX16vH5mTNs27YNX19f+9ZqJ+np6bfvdZ6baYr//POPxRAvW7bs7XnnmS/xd6WLiDJu7yzh7xoyhnJ79uxJZGSkW8zAcs/wzwj+3NyLQ2vUjRu02bSJluPH85CTBX/GRUS5GW65cOECRYsWtXg2/uSTT961vGjRom7xn8SSkJAQFi5caHQZwgoyhnInTJhA9+7djS7Hbtxv2Gf3bggPvyP4vwBmAYeAruavLfL2hs2bDb00Oy0t7a57nd/rLD0tLc3iuLmlgC9VqhQFChQw7GdzJidPnqRRo0acPn3a6FJEHkRHR/Phhx+yePFiGjRoYHQ5ViHDPtkZO/bOe24A5YD3MX1inWzpNRmSk02vX7rUauVorS12IsruTD3jQ0ZLIZ55znnme52769m5LT322GOkpKRw9uxZypYta3Q54j5l9NFevXo1W7duddmh3Htxr/BPSDB9uJvlt52O5j/3YLo8OVtam27alJh4z3t03Lp16/bZeW76hHp4eFg8G/f19SUsLOyO5XIRkWNQShESEsKePXto06aN0eWI+3D16lW6devGjRs32L59u9vO2HKvFJk1K8+bSEtP58jQoWyvXz/bs/QrV67cvogo63CLv7//XdMULd0jRji+jA99Jfydx6lTp2jTpg2hoaFMmTLFrYc53Sv8Dx68q9ny/fK4eZMLGzey33zv84yLiDKHfMmSJR16mqKwjlDz9F/hHDL6aA8ePJihQ4e6/XCoe4X/5ctW2UzjWrVoPHWqVbYlnFdGYxettdsHiaPLaL4yffp02rdvb3Q5DsG9Tk+LFbPOdtx0jFDcqVy5cnh6evLHH38YXYrIhtaa8ePH88Ybb7BmzRoJ/kzcK/xr1AALV+2lAilAmvmRYl5mkZeXqTGDEJiGfmx+Jbp4IDdv3uTll19mwYIF7Nixg9q1axtdkkNxr/Dv3dvi4jGAFzAOmGf+ekw2m9Dp6dluR7ifjA99hWNJSkrimWeeISEhgS1bttzddUu4Wfj7+Jju1ZNlfDYS0FkekRZeng78kJ7O0HHj+Pvvv21bq3AKEv6OJy4ujrCwMGrVqsXy5cuuj0W9AAAXHklEQVTv3XXLjblX+IPpJm0PeAfIfN7e1I2J4datWwQGBjJkyBA5CLi5kJAQ9u3bR3p6utGlCEzNVxo0aMCbb77JhAkTXKbrli24X/iHhkJUlOlWDffD2xuiovBp2ZJJkyZx+PBh0tPTCQwMZPDgwfz111+2qVc4tJIlS1KqVCl+++03o0txe3PnzuXZZ59l7ty5vPLKK0aX4/DcL/wB+vf/3wEgpyl6St0Ofvr3v724XLlyfPbZZxw5coR8+fJRvXp13njjDc6cydrETLg6GfoxVnp6Oh988AGjRo1i06ZNcqfVXHLP8AdTkG/eDB06mGYAZR0K8vIyLe/QwbRepuDPrGzZskyYMIGjR49SsGBBgoKCGDhwoNzwy43IjB/jJCcn061bN9avX8/OnTsJDAw0uiSn4b7hD6a7cy5dCn/+CaNHQ48e0Lq16c/Ro03Lly7N1V08H3nkEaKiojh+/Dje3t7UrFmTAQMGcOrUKTv8IMJIcuZvjHPnztGkSRPy5cvHhg0bXLrrli243y2d7SQxMZGoqCimT5/O888/z4gRI6hUqZLRZQkbuHbtGo888ghJSUlufa8Yezp8+DBt2rShV69ejBo1Sq6wziS3t3R27zN/GypdujSffPIJJ06coESJEtSuXZtXXnlFrgZ1QYULF6Zy5cocPnzY6FLcwpo1a2jSpAljxoxxm65btiDhb2OlSpVi7NixnDhxglKlShEcHMzLL7/M77//bnRpwooy7vMjbCs6OprevXuzbNkyXnjhBaPLcWoS/nby8MMP8/HHHxMbG8sjjzxCaGgoL774IidPnjS6NGEFMu5vW2lpaQwePJhJkyaxdetWl+m6ZSQJfzsrWbIkH330EbGxsZQvX546derQp08f4uLijC5N5IHM+LGdq1ev0r59ew4fPsz27dvdsuuWLUj4G6REiRKMHj2a2NhYKlWqRL169ejVqxexsbFGlyYeQM2aNTlx4gTJyfdsBCru06lTp2jQoAFly5Zl1apVbtt1yxYk/A1WokQJIiMjiYuLw9fXl/r169OjRw+5YtTJeHp6Uq1aNQ4cOGB0KS5jz549hIWF0bNnT6ZOnSozqaxMwt9BFC9enJEjRxIXF0dAQAANGjSge/fuHD9+3OjSRC7Jh77Ws2zZMiIiIvjiiy+k65aNSPg7mGLFivH+++8THx9PYGAgjRo1olu3bhw7dszo0kQO5EPfvMtovjJo0CBpvmJjEv4OqmjRorz77rvEx8dTo0YNwsPD6dKlC0eOHDG6NJEN+dA3b27evMlLL73EwoUL2blzpzRfsTEJfwdXpEgRhg8fTnx8PE8++SRNmjTh+eeflwuKHFBgYCCnT5/mypUrRpfidDKar5w/f56ff/6ZRx991OiSXJ6Ev5MoXLgw77zzDvHx8YSGhtKsWTM6derEwYMHjS5NmOXPn5+aNWuyd+9eo0txKnFxcdSrV48nn3ySZcuWSfMVO5HwdzKFCxfmrbfeIj4+nrCwMFq0aEHHjh1llomDkHH/+5PRfGXIkCF8+umn0nzFjiT8ndRDDz3E0KFDiY+Pp2HDhrRs2ZIOHTqwf/9+o0tzazLjJ/fmzJlDp06dpPmKQST8nZy3tzdvvvkm8fHxhIeH07p1a9q1aydDDwaRM/+cpaen8/777xMZGcnGjRul+YpBJPxdhJeXF4MGDSIuLo5mzZrRrl072rRpI7NP7MzPz49Lly6RmJhodCkOKTk5ma5du7JhwwZpvmIwCX8X4+Xlxeuvv05cXBwtWrSgffv2tGrVil9++cXo0txCvnz5CAkJkYOuBefOnaNx48Z4eHhI8xUHIOHvogoVKsTAgQOJj4+nVatWdOrUiYiICHbu3Gl0aS5Phn7udvjwYerVq8czzzzD/PnzKVSokNEluT0Jfxfn6enJgAEDiI2NpV27dnTu3JkWLVqwfft2o0tzWRL+d1q9erU0X3FAeQp/pVRJpdQ6pVSs+U+Lt9xTSqUppQ6YHyvysk/xYDw9PXn11VeJjY3l2WefpVu3bjz99NNs3brV6NJcTsaMH0dtkWpPU6ZMoU+fPixfvlyarziYvJ75DwfWa639gfXm7y1J1lrXMj/a5nGfIg8KFixIv379OHHiBJ07d6ZHjx40a9aMLVu2GF2ay6hQoQJaa06fPm10KYbJaL7y3//+l23btvHUU08ZXZLIIq/h3w6Ybf56NiB3YXISBQsW5KWXXuLEiRN069aN3r1706RJEzZv3mx0aU5PKeXW9/m5evUq7dq14/Dhw+zYsYPHH3/c6JKEBXkN/zJa67Pmr/8GymSzXiGl1B6l1E6llBwgHEiBAgXo27cvx48fp2fPnrz44ouEh4ezceNGGbbIA3cd989ovvLoo4+yatUqihcvbnRJIhs5hr9S6iel1GELj3aZ19OmpMguLSpprUOAbsBnSimLfdiUUv3MB4k9Mk/avgoUKEDv3r05fvw4ffr0oV+/fvzrX/9iw4YNchB4AO4Y/rt3777dke7LL7+U5iuOTmv9wA/gN6Cs+euywG+5eM0soFNO6wUHB2thnFu3buk5c+boKlWq6AYNGuh169bp9PR0o8tyGufOndPFixd3m/ds6dKlulSpUjomJsboUtwesEfnIr/zOuyzAuhl/roX8F3WFZRSJZRSnuavSwFPAUfzuF9hY/nz56dHjx4cPXqUV199lYEDB9KgQQPWrl0rvwnkgo+PD0WLFiUuLs7oUmxKa80nn3xyu/lKu3btcn6RcAh5Df9xwNNKqVigmfl7lFIhSqkZ5nWqAXuUUr8CG4FxWmsJfyfh4eHBCy+8wJEjRxg4cCCDBw+mfv36rF69Wg4COXD1oZ+M5iuLFi2S5itOKE/hr7W+oLVuqrX211o301pfNC/fo7V+yfz1dq11kNa6pvnPr6xRuLAvDw8PunbtyqFDhxg8eDBDhw4lLCyMlStXykEgG6484+fixYu0aNFCmq84MbnCV9wXDw8POnfuzKFDhxg6dChvv/02devW5YcffpCDQBaueuYfGxtLWFgYwcHB0nzFiUn4iweSL18+nnvuOQ4ePMjbb7/Nu+++S2hoKN9//70cBMyCg4M5cOAAqampRpdiNT///DMNGzZk6NChREVFSfMVJybhL/IkX758dOrUiQMHDvDuu+/ywQcfEBISwnfffef2B4FixYpRrlw5jh07ZnQpVpG5+Uq/fv2MLkfkkYS/sIp8+fLRsWNH9u3bxwcffEBkZCS1a9dm+fLlpKenG12eYVxh6Cej+cro0aPZtGmTNF9xERL+wqry5ctH+/bt2bdvH6NHj2bMmDE8+eSTLF261C0PAs7+oW9ycjJdunRh48aN0nzFxUj4C5tQStG2bVv27NnDxx9/zLhx46hVqxaLFy92q4OAM5/5ZzRfKVCgAOvXr6d06dJGlySsSMJf2JRSitatW/PLL78wbtw4/vOf/1CjRg0WLVpEWlqa0eXZXK1atTh69Cj//POP0aXcl8OHD1O3bl0iIiKYN2+eNF9xQRL+wi6UUrRs2ZJdu3bxn//8h4kTJxIUFMTChQtd+iDg7e2Nv78/Bw8eNLqUXMtovvLxxx8zatQoab7ioiT8hV0ppYiIiGDHjh1MnDiRSZMmUb16db755huXPQhkNHdxBpMnT5bmK25Cwl8YQilFixYt2LZtG5MmTWLKlCk88cQTzJs3z6XmxYNzjPunpaUxaNAgJk+eLM1X3ISEvzCUUoqnn36aLVu2MHnyZKZNm0ZgYCBz5sxxmYOAo8/4yWi+cvToUbZv3y7NV9yEhL9wCEopmjZtyubNm5k6dSozZ86kWrVqzJo1y+kPAkFBQZw8eZLr168bXcpd/vzzz9vNV1auXCnNV9yIhL9wKEopGjduzKZNm5g+fTqzZ88mICCAmTNncuvWLaPLeyAFChQgKCiIffv2GV3KHXbv3k39+vWl+YqbkvAXDiujneTXX3/N/PnzCQgIYMaMGU55EHC0cf+lS5fSsmVLpkyZwpAhQ2RGjxuS8BcOr1GjRqxfv545c+awaNEiqlSpwvTp07l586bRpeWao8z40Vozbtw4Bg8ezJo1a2jbtq3RJQmDSPgLp9GgQQPWrVvH/PnzWbJkCVWqVGHq1KlOcRBwhDP/mzdv8uKLL/Ltt99K8xUh4S+cT/369VmzZg0LFiwgJiYGPz8/oqOjHfoq2oCAABISEkhKSjJk/xnNVy5cuCDNVwQg4S+cWFhYGKtWrWLx4sV8//33+Pn5MXnyZFJSUowu7S4eHh7Url3bkCmfsbGx1KtXT5qviDtI+AunV7duXVauXMnSpUtZtWoVfn5+/Pe//3W4g4ARQz+bN2+mYcOGDBs2TJqviDtI+AuXUadOHX744QdiYmJYt24dvr6+fP755yQnJxtdGmD/8J89ezbPPfcc8+bNk+Yr4i4S/sLlhISEsGLFCr7//ns2btyIr68vn332meEHAXvN+ElPT+e9997jww8/ZPPmzTRr1szm+xTOR8JfuKzatWsTExPDypUr+fnnn/H19WXChAncuHHDkHoee+wxUlJSOHv2rM32kZycTOfOndm0aRM7d+6kWrVqNtuXcG4S/sLl1apVi2XLlrFq1Sq2b9+Or68vUVFRdr/dglKKkJAQm33o+/fffxMeHk7BggWl+YrIkYS/cBs1a9ZkyZIlrFmzhl27duHr68v48eO5du2a3Wqw1bj/oUOHqFevHq1atZLmKyJXJPyF26lRowaLFy/mp59+Yu/evfj6+jJu3DiuXr1q833bIvxXr15N06ZN+fe//83IkSPlVg0iVyT8hduqXr06ixYtYuPGjfz666/4+vry73//mytXrthsnxkf+mqtrbK9L7744nbzlW7dulllm8I9SPgLtxcYGMiCBQvYvHkzR44cwc/Pj48//tgmB4Fy5crh6enJH3/8kaftpKam8sYbbzBlyhRpviIeiIS/EGbVqlVj/vz5bNmyhePHj+Pr68tHH33E5cuXrbqfvDZ3yWi+cvz4cWm+Ih6YhL8QWQQEBDB37ly2bdtGXFwcfn5+jB49mkuXLlll+3kZ9//zzz956qmnqFChAj/++KM0XxEPTMJfiGxUqVKF2bNns2PHDv744w/8/PwYNWpUnm/O9qDh/8svvxAWFkbv3r2Jjo6W5isiTyT8hciBn58fX3/9Nbt27eLUqVP4+/vzwQcfcPHixQfaXkhICPv27SM9PT3Xr1myZAmtWrUiOjpamq8Iq5DwFyKXfH19mTlzJr/88gtnz56lSpUqvP/++1y4cOG+tlMyNZUR+fNzpV07aNMGuneH8eMhMfGudbXWjB07ljfffJO1a9dK8xVhNRL+Qtynxx9/nBkzZrBnzx4SEhKoUqUK7777LufPn7/3C3fvho4doVIl3rx8meI//AA//ADz50NkJFSsaHrePCR08+ZN+vbty+LFi9m5cydPPvmk7X844TYk/IV4QJUrV2batGns27ePixcvEhAQwPDhw0m0cAZPdDSEh0NMDKSk4JmWdufzycmQkmJ6Pjyc61FRNG/enKSkJLZs2SLNV4TVSfgLkUeVKlXiyy+/ZP/+/Vy5coWqVavy9ttvk5CQYFohOhqGDYMbNyCni7u0hhs3UG+/zesFCrB06VIeeugh2/8Qwu1I+AthJRUrVmTKlCkcOHCA69evU7VqVT7v3h09dKgp+M3+AV4EKgFFgFrAqizb8taaZ7dvx2P/frvVL9xLnsJfKfWcUuqIUipdKRVyj/WeUUr9ppSKU0oNz8s+hXB0FSpUYPLkyRw8eJDwHTtIz9JHIBWoAGwGLgNjgOeBP7JuKDkZxo61fcHCLeX1zP8w0BH4ObsVlFIewGQgAggEuiqlAvO4XyEcXvmCBan5119kbZz4EBAJVMb0H7A18BiwN+sGtIaVKy3OAhIir/IU/lrrY1rr33JYrQ4Qp7U+qbW+CSwE2uVlv0I4hVmzcrXaOeAE8ISlJ5XK9XaEuB/2GPN/FDiV6fvT5mVCuLaDB00zeO7hFvAC0AuoammF5GQ4dMj6tQm3lz+nFZRSPwGPWHjqPa31d9YsRinVD+gHpg/PhHBqOdwQLh3oARQEvrjXinm8nYQQluQY/lrrvHZ/PoPp860M5c3LLO1rGjANICQkxDo3PBfCKMWKZfuUxjTj5xywErjnXXpKlLBqWUKAfYZ9dgP+SqnHlFIFgS7ACjvsVwhj1agB2bRT7A8cA74HvO61DS8vCAqyfm3C7eV1qmcHpdRpIAz4USm1xry8nFJqJYDWOhUYCKzB9O/9W631kbyVLYQT6N3b4uL/A6YCBzCNpxY2P+ZbWlnrbLcjRF7kOOxzL1rr5cByC8v/Alpm+n4lpt9uhXAfPj4QEWG6ZUOmK3srYRr2yZFS0LIllC5tqwqFG5MrfIWwpREjTEM3D8LLy/R6IWxAwl8IWwoNhago8Pa+v9d5e5teF5LthfNC5Emehn2EELnQv7/pz2HDTPP273VzN6VMZ/xRUf97nRA2IGf+QthD//6weTN06GCaAZR1KMjLy7S8QwfTehL8wsbkzF8IewkJgaVLTffqmTXLdOVuUpJpHn9QkGlWj3y4K+xEwl8IeytdGt56y+gqhJuTYR8hhHBDEv5CCOGGJPyFEMINSfgLIYQbkvAXQgg3JOEvhBBuSMJfCCHckIS/EEK4IaXvdZ8RAymlEjHd+tyeSgHn7bxPRyfviWXyvtxN3hPL7P2+VNJa53ipuMOGvxGUUnu01nIbxUzkPbFM3pe7yXtimaO+LzLsI4QQbkjCXwgh3JCE/52mGV2AA5L3xDJ5X+4m74llDvm+yJi/EEK4ITnzF0IIN+TW4a+Uek4pdUQpla6UyvbTeKXUM0qp35RScUqp4fas0d6UUiWVUuuUUrHmP0tks16aUuqA+bHC3nXaS05/90opT6XUIvPzu5RSle1fpX3l4j3prZRKzPTv4yUj6rQnpdRMpVSCUupwNs8rpdQk83t2UClV2941ZuXW4Q8cBjoCP2e3glLKA5gMRACBQFelVKB9yjPEcGC91tofWG/+3pJkrXUt86Ot/cqzn1z+3b8IJGmt/YCJwCf2rdK+7uP/w6JM/z5m2LVIY8wCnrnH8xGAv/nRD4i2Q0335Nbhr7U+prX+LYfV6gBxWuuTWuubwEKgne2rM0w7YLb569lAewNrMVpu/u4zv19LgKZKKWXHGu3N3f4/5IrW+mfg4j1WaQfM0SY7geJKqbL2qc4ytw7/XHoUOJXp+9PmZa6qjNb6rPnrv4Ey2axXSCm1Rym1UynlqgeI3Pzd315Ha50KXAYetkt1xsjt/4dnzcMbS5RSFexTmkNzuBxx+R6+SqmfgEcsPPWe1vo7e9fjCO71nmT+RmutlVLZTQerpLU+o5R6HNiglDqktY63dq3CKX0PLNBa/6OUegXTb0ZNDK5JZOHy4a+1bpbHTZwBMp+5lDcvc1r3ek+UUueUUmW11mfNv5YmZLONM+Y/TyqlNgFPAq4W/rn5u89Y57RSKj9QDLhgn/IMkeN7orXO/PPPAMbboS5H53A5IsM+OdsN+CulHlNKFQS6AC47uwXTz9bL/HUv4K7fjpRSJZRSnuavSwFPAUftVqH95ObvPvP71QnYoF374pkc35MsY9ltgWN2rM9RrQB6mmf91AMuZxpeNYbW2m0fQAdMY2//AOeANebl5YCVmdZrCZzAdGb7ntF12/g9eRjTLJ9Y4CegpHl5CDDD/HV94BDwq/nPF42u24bvx11/98CHQFvz14WAxUAc8AvwuNE1O8B7MhY4Yv73sRGoanTNdnhPFgBngVvmTHkReBV41fy8wjRLKt78fybE6JrlCl8hhHBDMuwjhBBuSMJfCCHckIS/EEK4IQl/IYRwQxL+QgjhhiT8hRDCDUn4CyGEG5LwF0IIN/T/LIKAJVz4GHsAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f4925562198>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import networkx as nx\n",
@@ -31,12 +13,12 @@
     "\n",
     "from pyquil.api import get_qc\n",
     "\n",
-    "# ideal_qc = get_qc('4q-qvm', noisy=False)\n",
-    "noisy_qc = get_qc(\"Aspen-3-7Q-A\")\n",
+    "ideal_qc = get_qc('4q-qvm', noisy=False)\n",
+    "noisy_qc = get_qc(\"4q-noisy-qvm\", noisy=True)\n",
     "\n",
-    "qubits = noisy_qc.qubits()\n",
+    "qubits = ideal_qc.qubits()\n",
     "print(qubits)\n",
-    "graph = noisy_qc.qubit_topology()\n",
+    "graph = ideal_qc.qubit_topology()\n",
     "nx.draw_networkx(graph, with_labels=True)"
    ]
   },
@@ -49,417 +31,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from forest_benchmarking.quantum_volume import *\n",
+    "from forest_benchmarking.quantum_volume import measure_quantum_volume\n",
     "\n",
     "import logging\n",
     "logger = logging.getLogger()\n",
     "logger.setLevel(logging.INFO)\n",
-    "show_progress_bar = True\n",
-    "\n",
-    "from time import time"
+    "show_progress_bar = True"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "135.61787796020508\n",
-      "0.501314640045166\n",
-      "136.28105354309082\n",
-      "{2: (0.7984, 0.7520739900271997), 3: (0.8514666666666667, 0.8104022973225549)}\n"
-     ]
-    }
-   ],
-   "source": [
-    "start = time()\n",
-    "df = quantum_volume_dataframe(qubits=[1,2,3], num_circuits=300, depths=[2,3])\n",
-    "df = add_circuits_to_dataframe(df)\n",
-    "df, data_acq_time = acquire_qv_data(df, ideal_qc, num_shots=500, use_active_reset=False)\n",
-    "print(data_acq_time)\n",
-    "final_df1, total_sim_time = acquire_heavy_hitters(df)\n",
-    "print(total_sim_time)\n",
-    "end = time()\n",
-    "print(end - start)\n",
-    "\n",
-    "probs_and_errors = get_results_by_depth(final_df1)\n",
-    "print(probs_and_errors)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "138.66465878486633\n",
-      "0.5087440013885498\n",
-      "139.33286547660828\n",
-      "{2: (0.5044533333333333, 0.4467205964824244), 3: (0.84524, 0.8034772825916064)}\n"
-     ]
-    }
-   ],
-   "source": [
-    "start = time()\n",
-    "df = quantum_volume_dataframe(qubits=[1,2,3], num_circuits=300, depths=[2,3])\n",
-    "df = add_circuits_to_dataframe(df)\n",
-    "df, data_acq_time = acquire_qv_data(df, noisy_qc, num_shots=500, use_active_reset=True)\n",
-    "print(data_acq_time)\n",
-    "final_df2, total_sim_time = acquire_heavy_hitters(df)\n",
-    "print(total_sim_time)\n",
-    "end = time()\n",
-    "print(end - start)\n",
-    "\n",
-    "probs_and_errors = get_results_by_depth(final_df2)\n",
-    "print(probs_and_errors)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = quantum_volume_dataframe(qubits=[1, 2, 3], num_circuits=200, depths=[2,3])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df = add_circuits_to_dataframe(df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "102.20563054084778\n"
-     ]
-    }
-   ],
-   "source": [
-    "df, data_acq_time = acquire_qv_data(df, noisy_qc, num_shots=100, use_active_reset = False)\n",
-    "print(data_acq_time)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11663532257080078\n"
-     ]
-    }
-   ],
-   "source": [
-    "df, total_sim_time = acquire_heavy_hitters(df)\n",
-    "print(total_sim_time)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{2: (0.54015, 0.4696676649790886), 3: (0.7777, 0.7188981785996386)}\n"
-     ]
-    }
-   ],
-   "source": [
-    "prob_and_errors = get_results_by_depth(df)\n",
-    "print(prob_and_errors)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "        Qubits  Depth                                            Circuit  \\\n",
-      "0       {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.08354564-0.55237344j...   \n",
-      "1       {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.45098557-0.19330812j...   \n",
-      "2       {1, 2}      2  ([[0, 1], [1, 0]], [[[[ 0.18817431-0.35541579j...   \n",
-      "3       {1, 2}      2  ([[0, 1], [0, 1]], [[[[-0.30056824+0.09468738j...   \n",
-      "4       {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.01248778+0.58819779j...   \n",
-      "5       {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.04556996-0.04822739j...   \n",
-      "6       {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.12018575-0.53868308j...   \n",
-      "7       {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.0343568 -0.20436334j...   \n",
-      "8       {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.42441048+0.28562384j...   \n",
-      "9       {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.21779237-0.33540124j...   \n",
-      "10      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.21324399+0.14784112j...   \n",
-      "11      {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.40989358-0.53365489j...   \n",
-      "12      {1, 2}      2  ([[1, 0], [1, 0]], [[[[-0.56473235+0.31100909j...   \n",
-      "13      {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.11473532+0.70659771j...   \n",
-      "14      {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.384001  -0.23145849j...   \n",
-      "15      {1, 2}      2  ([[0, 1], [1, 0]], [[[[ 0.45945426+0.55874572j...   \n",
-      "16      {1, 2}      2  ([[0, 1], [0, 1]], [[[[ 0.10240352+0.14057013j...   \n",
-      "17      {1, 2}      2  ([[0, 1], [0, 1]], [[[[ 0.27378459+0.39529079j...   \n",
-      "18      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.69048299+0.01094889j...   \n",
-      "19      {1, 2}      2  ([[0, 1], [1, 0]], [[[[-4.62333395e-02-0.34586...   \n",
-      "20      {1, 2}      2  ([[0, 1], [0, 1]], [[[[-0.36045097+0.54366714j...   \n",
-      "21      {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.50184681+0.1789568j ...   \n",
-      "22      {1, 2}      2  ([[0, 1], [1, 0]], [[[[-0.24340445+0.54794529j...   \n",
-      "23      {1, 2}      2  ([[1, 0], [0, 1]], [[[[ 0.09083408-0.52767336j...   \n",
-      "24      {1, 2}      2  ([[0, 1], [0, 1]], [[[[ 0.32536565+0.14520539j...   \n",
-      "25      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.20546105-0.33535614j...   \n",
-      "26      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.29290167+0.10086655j...   \n",
-      "27      {1, 2}      2  ([[1, 0], [0, 1]], [[[[-0.09084294-0.52597991j...   \n",
-      "28      {1, 2}      2  ([[1, 0], [1, 0]], [[[[-0.01998412+0.02629819j...   \n",
-      "29      {1, 2}      2  ([[1, 0], [1, 0]], [[[[ 0.20894039-0.65290347j...   \n",
-      "..         ...    ...                                                ...   \n",
-      "370  {1, 2, 3}      3  ([[1, 0, 2], [0, 2, 1], [1, 0, 2]], [[[[-0.230...   \n",
-      "371  {1, 2, 3}      3  ([[1, 2, 0], [0, 1, 2], [2, 1, 0]], [[[[ 0.048...   \n",
-      "372  {1, 2, 3}      3  ([[1, 0, 2], [2, 1, 0], [1, 2, 0]], [[[[-0.039...   \n",
-      "373  {1, 2, 3}      3  ([[2, 1, 0], [2, 1, 0], [1, 0, 2]], [[[[-0.130...   \n",
-      "374  {1, 2, 3}      3  ([[0, 1, 2], [2, 1, 0], [1, 2, 0]], [[[[-0.162...   \n",
-      "375  {1, 2, 3}      3  ([[0, 2, 1], [2, 0, 1], [0, 2, 1]], [[[[-0.267...   \n",
-      "376  {1, 2, 3}      3  ([[1, 0, 2], [1, 0, 2], [1, 0, 2]], [[[[-0.260...   \n",
-      "377  {1, 2, 3}      3  ([[2, 1, 0], [2, 0, 1], [1, 0, 2]], [[[[ 0.120...   \n",
-      "378  {1, 2, 3}      3  ([[1, 2, 0], [2, 1, 0], [2, 0, 1]], [[[[-0.593...   \n",
-      "379  {1, 2, 3}      3  ([[0, 2, 1], [2, 0, 1], [2, 1, 0]], [[[[ 0.357...   \n",
-      "380  {1, 2, 3}      3  ([[2, 1, 0], [1, 2, 0], [0, 1, 2]], [[[[ 0.291...   \n",
-      "381  {1, 2, 3}      3  ([[1, 0, 2], [0, 1, 2], [0, 1, 2]], [[[[ 0.648...   \n",
-      "382  {1, 2, 3}      3  ([[0, 1, 2], [2, 1, 0], [1, 0, 2]], [[[[-0.257...   \n",
-      "383  {1, 2, 3}      3  ([[1, 2, 0], [1, 0, 2], [0, 2, 1]], [[[[-0.138...   \n",
-      "384  {1, 2, 3}      3  ([[1, 0, 2], [2, 0, 1], [0, 2, 1]], [[[[ 0.437...   \n",
-      "385  {1, 2, 3}      3  ([[1, 0, 2], [2, 1, 0], [1, 0, 2]], [[[[ 0.166...   \n",
-      "386  {1, 2, 3}      3  ([[0, 1, 2], [2, 1, 0], [2, 0, 1]], [[[[-0.480...   \n",
-      "387  {1, 2, 3}      3  ([[2, 0, 1], [1, 0, 2], [1, 0, 2]], [[[[ 0.383...   \n",
-      "388  {1, 2, 3}      3  ([[2, 0, 1], [2, 0, 1], [0, 1, 2]], [[[[ 0.028...   \n",
-      "389  {1, 2, 3}      3  ([[0, 2, 1], [0, 2, 1], [2, 1, 0]], [[[[-0.172...   \n",
-      "390  {1, 2, 3}      3  ([[0, 2, 1], [2, 0, 1], [2, 1, 0]], [[[[ 0.173...   \n",
-      "391  {1, 2, 3}      3  ([[0, 1, 2], [2, 0, 1], [2, 0, 1]], [[[[ 0.436...   \n",
-      "392  {1, 2, 3}      3  ([[2, 1, 0], [2, 1, 0], [2, 0, 1]], [[[[ 0.614...   \n",
-      "393  {1, 2, 3}      3  ([[1, 2, 0], [1, 0, 2], [0, 2, 1]], [[[[ 0.455...   \n",
-      "394  {1, 2, 3}      3  ([[2, 0, 1], [1, 2, 0], [1, 2, 0]], [[[[ 0.239...   \n",
-      "395  {1, 2, 3}      3  ([[2, 0, 1], [1, 2, 0], [2, 0, 1]], [[[[ 0.387...   \n",
-      "396  {1, 2, 3}      3  ([[1, 2, 0], [2, 0, 1], [2, 1, 0]], [[[[-0.071...   \n",
-      "397  {1, 2, 3}      3  ([[0, 1, 2], [0, 2, 1], [0, 1, 2]], [[[[-0.236...   \n",
-      "398  {1, 2, 3}      3  ([[1, 0, 2], [0, 2, 1], [2, 0, 1]], [[[[ 0.131...   \n",
-      "399  {1, 2, 3}      3  ([[1, 0, 2], [0, 1, 2], [1, 2, 0]], [[[[-0.583...   \n",
-      "\n",
-      "                                               Results   RunTime  \\\n",
-      "0    [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0], [0, 1...  0.291788   \n",
-      "1    [[0, 1], [0, 1], [0, 1], [1, 0], [1, 1], [0, 1...  0.181660   \n",
-      "2    [[1, 1], [1, 1], [0, 0], [1, 0], [1, 0], [1, 1...  0.180506   \n",
-      "3    [[1, 0], [1, 0], [1, 0], [1, 0], [1, 0], [1, 1...  0.177028   \n",
-      "4    [[0, 0], [0, 0], [1, 0], [1, 1], [0, 1], [1, 0...  0.179637   \n",
-      "5    [[0, 0], [0, 0], [0, 0], [1, 1], [0, 1], [0, 1...  0.191679   \n",
-      "6    [[1, 1], [0, 0], [0, 1], [0, 0], [0, 0], [1, 1...  0.250205   \n",
-      "7    [[0, 0], [1, 0], [1, 0], [0, 1], [0, 0], [0, 0...  0.183192   \n",
-      "8    [[0, 1], [0, 1], [1, 1], [1, 1], [0, 1], [0, 1...  0.190195   \n",
-      "9    [[0, 1], [0, 0], [1, 0], [0, 1], [1, 1], [0, 0...  0.178466   \n",
-      "10   [[0, 0], [1, 1], [1, 1], [1, 0], [0, 0], [0, 0...  0.178089   \n",
-      "11   [[0, 0], [0, 1], [0, 0], [1, 0], [0, 0], [1, 1...  0.182206   \n",
-      "12   [[0, 0], [0, 0], [1, 1], [0, 0], [0, 0], [1, 1...  0.175373   \n",
-      "13   [[0, 0], [1, 1], [0, 0], [1, 0], [0, 1], [0, 1...  0.185450   \n",
-      "14   [[0, 0], [1, 0], [1, 0], [1, 0], [1, 0], [1, 0...  0.193900   \n",
-      "15   [[1, 0], [0, 0], [0, 0], [1, 0], [1, 0], [0, 0...  0.237631   \n",
-      "16   [[1, 1], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0...  0.202537   \n",
-      "17   [[0, 0], [1, 0], [1, 0], [1, 0], [1, 0], [1, 1...  0.180199   \n",
-      "18   [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0...  0.186573   \n",
-      "19   [[1, 1], [1, 0], [0, 1], [0, 1], [0, 1], [1, 1...  0.186149   \n",
-      "20   [[0, 1], [1, 1], [0, 1], [0, 1], [1, 0], [1, 1...  0.187587   \n",
-      "21   [[1, 1], [1, 0], [1, 0], [1, 0], [1, 1], [1, 1...  0.185353   \n",
-      "22   [[0, 1], [0, 0], [1, 1], [0, 1], [0, 1], [0, 1...  0.177998   \n",
-      "23   [[1, 0], [0, 1], [1, 0], [0, 1], [1, 0], [0, 0...  0.178340   \n",
-      "24   [[0, 0], [1, 0], [1, 0], [1, 0], [1, 0], [0, 0...  0.251029   \n",
-      "25   [[0, 0], [0, 0], [1, 1], [1, 1], [1, 0], [0, 0...  0.186509   \n",
-      "26   [[0, 0], [0, 1], [0, 1], [1, 0], [1, 0], [0, 1...  0.180358   \n",
-      "27   [[0, 0], [1, 0], [0, 1], [1, 0], [1, 0], [1, 0...  0.193331   \n",
-      "28   [[1, 0], [1, 0], [1, 0], [0, 0], [1, 0], [0, 0...  0.180303   \n",
-      "29   [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0...  0.185431   \n",
-      "..                                                 ...       ...   \n",
-      "370  [[0, 0, 1], [0, 0, 0], [0, 0, 0], [1, 0, 0], [...  0.335995   \n",
-      "371  [[1, 0, 0], [0, 0, 1], [1, 1, 1], [1, 1, 0], [...  0.339910   \n",
-      "372  [[1, 1, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0], [...  0.336974   \n",
-      "373  [[0, 1, 0], [0, 1, 1], [0, 1, 1], [0, 0, 0], [...  0.263358   \n",
-      "374  [[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0], [...  0.263503   \n",
-      "375  [[0, 0, 1], [1, 0, 0], [0, 0, 0], [0, 0, 0], [...  0.209372   \n",
-      "376  [[0, 0, 0], [1, 0, 0], [1, 0, 0], [1, 1, 0], [...  0.207757   \n",
-      "377  [[1, 0, 1], [0, 0, 0], [1, 1, 0], [0, 1, 1], [...  0.393412   \n",
-      "378  [[1, 0, 0], [1, 1, 1], [1, 0, 1], [0, 1, 0], [...  0.256955   \n",
-      "379  [[0, 1, 0], [0, 0, 0], [1, 1, 1], [1, 1, 1], [...  0.257491   \n",
-      "380  [[1, 0, 0], [1, 0, 0], [0, 0, 0], [1, 0, 0], [...  0.263339   \n",
-      "381  [[1, 1, 0], [0, 0, 0], [0, 0, 0], [1, 1, 0], [...  0.218792   \n",
-      "382  [[0, 0, 1], [0, 1, 1], [0, 0, 1], [1, 1, 1], [...  0.398403   \n",
-      "383  [[1, 0, 0], [0, 1, 1], [1, 0, 0], [0, 0, 1], [...  0.339747   \n",
-      "384  [[0, 0, 1], [0, 0, 0], [0, 0, 0], [1, 0, 0], [...  0.257747   \n",
-      "385  [[0, 0, 1], [0, 0, 1], [1, 0, 1], [1, 0, 1], [...  0.334514   \n",
-      "386  [[1, 0, 1], [0, 0, 0], [1, 0, 0], [0, 1, 0], [...  0.408417   \n",
-      "387  [[0, 0, 1], [0, 1, 0], [1, 0, 1], [1, 0, 1], [...  0.262085   \n",
-      "388  [[0, 0, 1], [1, 1, 0], [1, 0, 0], [0, 0, 1], [...  0.258457   \n",
-      "389  [[0, 0, 1], [1, 1, 1], [1, 0, 0], [0, 0, 0], [...  0.258218   \n",
-      "390  [[1, 0, 1], [0, 0, 0], [0, 1, 1], [0, 0, 0], [...  0.333805   \n",
-      "391  [[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 1, 1], [...  0.254135   \n",
-      "392  [[0, 0, 0], [1, 0, 1], [1, 0, 0], [1, 1, 1], [...  0.265176   \n",
-      "393  [[1, 0, 0], [1, 1, 1], [1, 1, 0], [0, 0, 0], [...  0.345715   \n",
-      "394  [[1, 0, 1], [0, 1, 0], [0, 1, 1], [1, 1, 0], [...  0.328683   \n",
-      "395  [[0, 1, 0], [1, 0, 1], [1, 1, 1], [1, 0, 0], [...  0.341782   \n",
-      "396  [[1, 0, 1], [0, 0, 0], [0, 0, 0], [1, 0, 1], [...  0.346028   \n",
-      "397  [[0, 1, 1], [0, 1, 1], [0, 0, 1], [0, 0, 1], [...  0.334668   \n",
-      "398  [[0, 1, 1], [1, 0, 1], [0, 0, 1], [0, 0, 1], [...  0.326390   \n",
-      "399  [[1, 1, 1], [0, 0, 1], [1, 0, 1], [0, 1, 0], [...  0.271829   \n",
-      "\n",
-      "     HeavyHitters   SimTime  NumHHSampled  \n",
-      "0    [0, 2, 4, 6]  0.000490            58  \n",
-      "1    [0, 2, 4, 6]  0.000204             9  \n",
-      "2    [0, 2, 4, 6]  0.000164            56  \n",
-      "3    [0, 2, 4, 6]  0.000153            74  \n",
-      "4    [0, 2, 4, 6]  0.000189            87  \n",
-      "5    [0, 2, 4, 6]  0.000180            71  \n",
-      "6    [0, 2, 4, 6]  0.000220            66  \n",
-      "7    [0, 2, 4, 6]  0.000212            61  \n",
-      "8    [0, 2, 4, 6]  0.000268            18  \n",
-      "9    [0, 2, 4, 6]  0.000309            65  \n",
-      "10   [0, 2, 4, 6]  0.000788            48  \n",
-      "11   [0, 2, 4, 6]  0.000212            59  \n",
-      "12   [0, 2, 4, 6]  0.000213            40  \n",
-      "13   [0, 2, 4, 6]  0.000188            46  \n",
-      "14   [0, 2, 4, 6]  0.000189            92  \n",
-      "15   [0, 2, 4, 6]  0.000207            85  \n",
-      "16   [0, 2, 4, 6]  0.000196            58  \n",
-      "17   [0, 2, 4, 6]  0.000184            48  \n",
-      "18   [0, 2, 4, 6]  0.000189            87  \n",
-      "19   [0, 2, 4, 6]  0.000324            32  \n",
-      "20   [0, 2, 4, 6]  0.000194            13  \n",
-      "21   [0, 2, 4, 6]  0.000194            63  \n",
-      "22   [0, 2, 4, 6]  0.000204            50  \n",
-      "23   [0, 2, 4, 6]  0.000238            41  \n",
-      "24   [0, 2, 4, 6]  0.000196            85  \n",
-      "25   [0, 2, 4, 6]  0.000204            59  \n",
-      "26   [0, 2, 4, 6]  0.000153            40  \n",
-      "27   [0, 2, 4, 6]  0.000118            81  \n",
-      "28   [0, 2, 4, 6]  0.000135            83  \n",
-      "29   [0, 2, 4, 6]  0.000189            74  \n",
-      "..            ...       ...           ...  \n",
-      "370  [0, 5, 6, 7]  0.000142            61  \n",
-      "371  [1, 4, 6, 7]  0.000145            83  \n",
-      "372  [2, 4, 6, 7]  0.000144            88  \n",
-      "373  [2, 3, 4, 6]  0.000145            63  \n",
-      "374  [0, 3, 4, 7]  0.000147            78  \n",
-      "375  [0, 1, 4, 5]  0.000145            97  \n",
-      "376  [0, 2, 4, 6]  0.000142            98  \n",
-      "377  [0, 4, 5, 6]  0.000153            83  \n",
-      "378  [2, 3, 5, 7]  0.000146            75  \n",
-      "379  [0, 1, 3, 7]  0.000146            82  \n",
-      "380  [0, 2, 4, 6]  0.000144            94  \n",
-      "381  [0, 2, 4, 6]  0.000144            98  \n",
-      "382  [1, 2, 4, 7]  0.000144            74  \n",
-      "383  [1, 3, 4, 5]  0.000144            74  \n",
-      "384  [0, 2, 4, 5]  0.000146            81  \n",
-      "385  [1, 3, 5, 7]  0.000146            82  \n",
-      "386  [0, 2, 6, 7]  0.000146            77  \n",
-      "387  [0, 2, 3, 5]  0.000143            79  \n",
-      "388  [0, 2, 4, 6]  0.000156            87  \n",
-      "389  [1, 3, 4, 7]  0.000147            73  \n",
-      "390  [0, 1, 3, 4]  0.000147            87  \n",
-      "391  [0, 2, 3, 4]  0.000144            86  \n",
-      "392  [1, 4, 5, 7]  0.000146            81  \n",
-      "393  [0, 1, 2, 5]  0.000145            78  \n",
-      "394  [1, 2, 3, 5]  0.000157            68  \n",
-      "395  [3, 4, 5, 7]  0.000145            72  \n",
-      "396  [0, 4, 5, 6]  0.000147            73  \n",
-      "397  [1, 2, 3, 4]  0.000148            74  \n",
-      "398  [1, 2, 5, 7]  0.000146            73  \n",
-      "399  [1, 4, 6, 7]  0.000144            76  \n",
-      "\n",
-      "[400 rows x 8 columns]\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(df)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -477,45 +59,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 200/200 [00:39<00:00,  5.13it/s]\n",
-      "100%|██████████| 200/200 [00:59<00:00,  3.36it/s]\n",
-      "100%|██████████| 200/200 [02:57<00:00,  1.13it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[(2, 0.794665, 0.7375383796247318, True), (3, 0.848665, 0.7979831062360531, True), (4, 0.841005, 0.7892912513493752, True)]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "ideal_outcomes = measure_quantum_volume(ideal_qc, num_circuits=200, show_progress_bar=show_progress_bar)\n",
-    "print(ideal_outcomes)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ideal_outcomes = [(2, 0.794665, 0.7375383796247318, True), (3, 0.848665, 0.7979831062360531, True), (4, 0.841005, 0.7892912513493752, True)]"
+    "ideal_outcomes = measure_quantum_volume(ideal_qc, num_circuits=200, show_progress_bar=show_progress_bar)"
    ]
   },
   {
@@ -662,30 +210,134 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## For more fine-grained control, create and maintain a dataframe"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from forest_benchmarking.quantum_volume import (generate_quantum_volume_experiments,\n",
+    "                                                add_programs_to_dataframe,\n",
+    "                                                acquire_quantum_volume_data,\n",
+    "                                                acquire_heavy_hitters,\n",
+    "                                                get_results_by_depth,\n",
+    "                                                extract_quantum_volume_from_results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get a dataframe with (depth x n_circuits) many \"Abstract Ckt\"s that describe each model circuit for each depth."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_circuits = 100\n",
+    "depths = [2,3]\n",
+    "df = generate_quantum_volume_experiments(depths, n_circuits)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the default program_generator to synthesize native pyquil programs that implement each ckt natively on the qc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = add_programs_to_dataframe(df, noisy_qc)\n",
+    "print(df[\"Program\"].values[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Run the programs. This can be slow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = acquire_quantum_volume_data(df, noisy_qc, num_shots=10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Classically simulate the circuits to get heavy hitters, and record how many hh were sampled for each program run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = acquire_heavy_hitters(df)\n",
+    "print(df[\"Num HH Sampled\"].values[0:10])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get estimates of the probability of sampling hh at each depth, and the lowerbound on that estimate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = get_results_by_depth(df)\n",
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the results to get a lower bound on the quantum volume"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qv = extract_quantum_volume_from_results(results)\n",
+    "qv"
+   ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/forest_benchmarking/quantum_volume.py
+++ b/forest_benchmarking/quantum_volume.py
@@ -57,6 +57,11 @@ def _naive_program_generator(qc: QuantumComputer, qubits: Sequence[int], permuta
 
     native_quil = qc.compiler.quil_to_native_quil(prog)
 
+    if not set(native_quil.get_qubits()).issubset(set(qubits)):
+        raise ValueError("naive_program_generator could not generate program using only the "
+                         "qubits supplied. Please provide your own program_generator if you wish "
+                         "to use only the qubits specified.")
+
     return native_quil
 
 
@@ -203,11 +208,10 @@ def calculate_prob_est_and_err(num_heavy: int, num_circuits: int, num_shots: int
 def measure_quantum_volume(qc: QuantumComputer, qubits: Sequence[int] = None,
                            program_generator: Callable[[QuantumComputer, Sequence[int],
                                                         np.ndarray, np.ndarray], Program] =
-                           _naive_program_generator,
-                           num_circuits: int = 100, num_shots: int = 1000,
+                           _naive_program_generator, num_circuits: int = 100, num_shots: int = 1000,
                            depths: np.ndarray = None, achievable_threshold: float = 2/3,
                            stop_when_fail: bool = True, show_progress_bar: bool = False) \
-                            -> Dict[int, Tuple[float, float, bool]]:
+        -> Dict[int, Tuple[float, float]]:
     """
     Measures the quantum volume of a quantum resource, as described in [QVol].
 
@@ -246,11 +250,11 @@ def measure_quantum_volume(qc: QuantumComputer, qubits: Sequence[int] = None,
         the one-sided confidence interval of this estimate is greater than the given threshold.
     :param stop_when_fail: if true, the measurement will stop after the first un-achievable depth
     :param show_progress_bar: displays a progress bar for each depth if true.
-    :return: depth: (prob_sample_heavy, ons_sided_conf_interval, is_achievable) dict indicating the
-        estimated probability of sampling a heavy output at each depth, a 2-sigma lower bound on
-        this estimate, and whether that depth qualifies as being achievable based on the lower bound
+    :return: dict with key depth: (prob_sample_heavy, ons_sided_conf_interval) gives both the
+        estimated probability of sampling a heavy output at each depth and the 2-sigma lower
+        bound on this estimate; a depth qualifies as being achievable only if this lower bound
+        exceeds the threshold, defined in [QVol] to be 2/3
     """
-
     if num_circuits < 100:
         warnings.warn("The number of random circuits ran ought to be greater than 100 for results "
                       "to be valid.")
@@ -277,7 +281,7 @@ def measure_quantum_volume(qc: QuantumComputer, qubits: Sequence[int] = None,
         # interval is larger than the threshold
         is_achievable = one_sided_conf_intrvl > achievable_threshold
 
-        results[depth] = (prob_sample_heavy, one_sided_conf_intrvl, is_achievable)
+        results[depth] = (prob_sample_heavy, one_sided_conf_intrvl)
 
         if stop_when_fail and not is_achievable:
             break
@@ -287,10 +291,19 @@ def measure_quantum_volume(qc: QuantumComputer, qubits: Sequence[int] = None,
 
 def generate_quantum_volume_experiments(depths: Sequence[int], num_circuits: int) -> DataFrame:
     """
+    Generate a dataframe with (depth * num_circuits) many rows each populated with an abstract
+    description of a model circuit of given depth=width necessary to measure quantum volume.
 
-    :param num_circuits:
-    :param depths:
-    :return:
+    See generate_abstract_qv_circuit and the reference [QVol] for more on the structure of each
+    circuit and the representation used here.
+
+    :param num_circuits: The number of circuits to run for each depth. Should be > 100
+    :param depths: The depths to measure. In order to properly lower bound the quantum volume of
+        a circuit, the depths should start at 2 and increase in increments of 1. Depths greater
+        than 4 will take several minutes for data collection. Further, the acquire_heavy_hitters
+        step involves a classical simulation that scales exponentially with depth.
+    :return: a dataframe with columns "Depth" and "Abstract Ckt" populated with the depth and an
+        abstract representation of a model circuit with that depth and width.
     """
     def df_dict():
         for d in depths:
@@ -306,12 +319,24 @@ def add_programs_to_dataframe(df: DataFrame, qc: QuantumComputer,
                                                            np.ndarray, np.ndarray], Program] =
                               _naive_program_generator) -> DataFrame:
     """
+    Passes the abstract circuit description in each row of the dataframe df along to the supplied
+    program_generator which yields a program that can be run on the available
+    qubits_at_depth[depth] on the given qc resource.
 
-    :param df:
-    :param qc:
-    :param qubits_at_depth:
-    :param program_generator:
-    :return:
+    :param df: a dataframe populated with abstract descriptions of model circuits, i.e. a df
+        returned by a call to generate_quantum_volume_experiments.
+    :param qc: the quantum resource on which each output program will be run.
+    :param qubits_at_depth: the qubits of the qc available for use at each depth, default all
+        qubits in the qc for each depth. Any subset of these may actually be used by the program.
+    :param program_generator: a method which uses the given qc, its available qubits, and an
+        abstract description of the model circuit to produce a PyQuil program implementing the
+        circuit using only native gates and the given qubits. This program must respect the
+        topology of the qc induced by the given qubits. The default _naive_program_generator uses
+        the qc's compiler to achieve this result.
+    :return: a copy of df with a new "Program" column populated with native PyQuil programs that
+        implement the circuit in "Abstract Ckt" on the qc using a subset of the qubits specified
+        as available for the given depth. The used qubits are also recorded in a "Qubits" column.
+        Note that although the abstract circuit has depth=width, for the program width >= depth.
     """
     new_df = df.copy()
 
@@ -324,22 +349,29 @@ def add_programs_to_dataframe(df: DataFrame, qc: QuantumComputer,
     else:
         qubits = [qubits_at_depth[depth] for depth in depths]
 
-    # these are all possible qubits allowed in the program, not necessarily measured or even used.
-    new_df["Qubits"] = Series(qubits)
-    new_df["Program"] = Series([program_generator(qc, qbits, *ckt) for qbits, ckt in zip(qubits,
-                                                                                         circuits)])
+    programs = [program_generator(qc, qbits, *ckt) for qbits, ckt in zip(qubits, circuits)]
+    new_df["Program"] = Series(programs)
+
+    # these are the qubits actually used in the program, a subset of qubits_at_depth[depth]
+    new_df["Qubits"] = Series([program.get_qubits() for program in programs])
+
     return new_df
 
 
 def acquire_quantum_volume_data(df: DataFrame, qc: QuantumComputer, num_shots: int = 1000,
                                 use_active_reset: bool = False) -> DataFrame:
     """
+    Runs each program in the dataframe df on the given qc and outputs a copy of df with results.
 
-    :param df:
-    :param qc:
-    :param num_shots:
-    :param use_active_reset:
-    :return:
+    :param df: a dataframe populated with PyQuil programs that can be run natively on the given qc,
+        i.e. a df returned by a call to add_programs_to_dataframe(df, qc, etc.) with identical qc.
+    :param qc: the quantum resource on which to run each program.
+    :param num_shots: the number of times to sample the output of each program.
+    :param use_active_reset: if true, speeds up the overall computation (only on a real qpu) by
+        actively resetting at the start of each program.
+    :return: a copy of df with a new "Results" column populated with num_shots many depth-bit arrays
+        that can be compared to the Heavy Hitters with a call to bit_array_to_int. There is also
+        a column "Run Time" which records the time taken to acquire the data for each program.
     """
     new_df = df.copy()
 
@@ -368,14 +400,25 @@ def acquire_quantum_volume_data(df: DataFrame, qc: QuantumComputer, num_shots: i
     new_df["Results"] = Series(results)
     new_df["Run Time"] = Series(times)
 
+    # supply the count of heavy hitters sampled if heavy hitters are known.
+    if "Heavy Hitters" in new_df.columns.values:
+        new_df = count_heavy_hitters_sampled(new_df)
+
     return new_df
 
 
 def acquire_heavy_hitters(df: DataFrame) -> DataFrame:
     """
+    Runs a classical simulation of each circuit in the dataframe df and records which outputs
+    qualify as heavy hitters in a copied df with newly populated "Heavy Hitters" column.
 
-    :param df:
-    :return:
+    An output is a heavy hitter if the ideal probability of measuring that output from the
+    circuit is greater than the median probability among all possible bitstrings of the same size.
+
+    :param df: a dataframe populated with abstract descriptions of model circuits, i.e. a df
+        returned by a call to generate_quantum_volume_experiments.
+    :return: a copy of df with a new "Heavy Hitters" column. There is also a column "Sim Time"
+        which records the time taken to simulate and collect the heavy hitters for each circuit.
     """
     new_df = df.copy()
 
@@ -388,7 +431,7 @@ def acquire_heavy_hitters(df: DataFrame) -> DataFrame:
 
         return heavy_outputs, end - start
 
-    circuits = new_df["Circuit"].values
+    circuits = new_df["Abstract Ckt"].values
     depths = new_df["Depth"].values
 
     data = [run(d, ckt) for d, ckt in zip(depths, circuits)]
@@ -399,14 +442,20 @@ def acquire_heavy_hitters(df: DataFrame) -> DataFrame:
     new_df["Heavy Hitters"] = Series(heavy_hitters)
     new_df["Sim Time"] = Series(times)
 
+    # supply the count of heavy hitters sampled if sampling results are known.
+    if "Results" in new_df.columns.values:
+        new_df = count_heavy_hitters_sampled(new_df)
+
     return new_df
 
 
 def count_heavy_hitters_sampled(df: DataFrame) -> DataFrame:
     """
+    Given a df populated with both sampled results and the actual heavy hitters, copies the df
+    and populates a new column with the number of samples which are heavy hitters.
 
-    :param df:
-    :return:
+    :param df: a dataframe populated with sampled results and heavy hitters.
+    :return: a copy of df with a new "Num HH Sampled" column.
     """
     new_df = df.copy()
 
@@ -421,7 +470,7 @@ def count_heavy_hitters_sampled(df: DataFrame) -> DataFrame:
         return num_heavy
 
     exp_results = new_df["Results"].values
-    heavy_hitters = new_df["HeavyHitters"].values
+    heavy_hitters = new_df["Heavy Hitters"].values
 
     new_df["Num HH Sampled"] = Series([count(hh, exp_res) for hh, exp_res in zip(heavy_hitters,
                                                                                  exp_results)])
@@ -429,11 +478,21 @@ def count_heavy_hitters_sampled(df: DataFrame) -> DataFrame:
     return new_df
 
 
-def get_results_by_depth(df: DataFrame) -> Dict[int, Tuple[float, float, bool]]:
+def get_results_by_depth(df: DataFrame) -> Dict[int, Tuple[float, float]]:
     """
+    Analyzes a dataframe df to determine an estimate of the probability of outputting a heavy
+    hitter at each depth in the df, a lower bound on this estimate, and whether that depth was
+    achieved.
 
-    :param df:
-    :return:
+    The output of this method can be fed directly into extract_quantum_volume_from_results to
+    obtain the quantum volume measured.
+
+    :param df: a dataframe populated with results, num hh sampled, and circuits for some number
+        of depths.
+    :return: for each depth key, provides a tuple of (estimate of probability of outputting hh for
+        that depth=width, 2-sigma confidence interval (lower bound) on that estimate). The lower
+        bound on the estimate is used to judge whether a depth is considered "achieved" in the
+        context of the quantum volume.
     """
     depths = df["Depth"].values
 
@@ -442,16 +501,16 @@ def get_results_by_depth(df: DataFrame) -> Dict[int, Tuple[float, float, bool]]:
         single_depth = df.loc[df["Depth"] == depth]
         num_shots = len(single_depth["Results"].values[0])
         num_heavy = sum(single_depth["Num HH Sampled"].values)
-        num_circuits = len(single_depth["Circuit"].values)
+        num_circuits = len(single_depth["Abstract Ckt"].values)
 
         prob_est, conf_intrvl = calculate_prob_est_and_err(num_heavy, num_circuits, num_shots)
 
-        results[depth] = (prob_est, conf_intrvl, conf_intrvl > 2/3)
+        results[depth] = (prob_est, conf_intrvl)
 
     return results
 
 
-def extract_quantum_volume_from_results(results: Dict[int, Tuple[float, float, bool]]) -> int:
+def extract_quantum_volume_from_results(results: Dict[int, Tuple[float, float]]) -> int:
     """
     Provides convenient extraction of quantum volume from the results returned by a default run of
     measure_quantum_volume above
@@ -463,8 +522,8 @@ def extract_quantum_volume_from_results(results: Dict[int, Tuple[float, float, b
 
     max_depth = 1
     for depth in depths:
-        (_, _, is_ach) = results[depth]
-        if not is_ach:
+        (_, lower_bound) = results[depth]
+        if lower_bound <= 2/3:
             break
         max_depth = depth
 

--- a/tests/test_quantum_volume.py
+++ b/tests/test_quantum_volume.py
@@ -1,14 +1,13 @@
 import numpy as np
 import warnings
-from pyquil.api import get_qc
-from forest_benchmarking.quantum_volume import measure_quantum_volume, extract_quantum_volume_from_results
+from forest_benchmarking.quantum_volume import *
 
 np.random.seed(1)
 
 
-def test_ideal_sim_heavy_probs():
-    qvm = get_qc('3q-pyqvm')
+def test_ideal_sim_heavy_probs(qvm):
     qvm.qam.random_seed = 1
+    depths = [2, 3]
 
     # silence warning from too few circuits, since 100 circuits is too slow
     with warnings.catch_warnings():
@@ -17,5 +16,67 @@ def test_ideal_sim_heavy_probs():
 
     assert extract_quantum_volume_from_results(outcomes) == 8
     target_probs = [0.788765, 0.852895]
-    probs = [val[1] for val in outcomes]
+    probs = [outcomes[depth][0] for depth in depths]
     np.testing.assert_allclose(probs, target_probs, atol=.02)
+
+
+def test_qv_df_generation():
+    depths = [2, 3]
+    n_ckts = 100
+
+    df = generate_quantum_volume_experiments(depths, n_ckts)
+    df_depths = df["Depth"].values
+    ckts = df["Abstract Ckt"].values
+
+    assert len(df_depths) == len(depths)*n_ckts
+
+    assert all([len(ckt[0]) == depth for ckt, depth in zip(ckts, df_depths)])
+    assert all([len(ckt[0][0]) == depth for ckt, depth in zip(ckts, df_depths)])
+
+    assert all([ckt[1].shape == (depth, depth//2, 4, 4) for ckt, depth in zip(ckts, df_depths)])
+
+
+def test_qv_data_acquisition(qvm):
+    depths = [2, 3]
+    n_ckts = 10
+    n_shots = 5
+
+    df = generate_quantum_volume_experiments(depths, n_ckts)
+    df = add_programs_to_dataframe(df, qvm)
+    df = acquire_quantum_volume_data(df, qvm, n_shots)
+
+    df_depths = df["Depth"].values
+    results = df["Results"].values
+
+    assert all([res.shape == (n_shots, depth) for res, depth in zip(results, df_depths)])
+
+
+def test_qv_count_heavy_hitters(qvm):
+    depths = [2, 3]
+    n_ckts = 10
+    n_shots = 5
+
+    df = generate_quantum_volume_experiments(depths, n_ckts)
+    df = add_programs_to_dataframe(df, qvm)
+    df = acquire_quantum_volume_data(df, qvm, n_shots)
+    df = acquire_heavy_hitters(df)
+
+    num_hhs = df["Num HH Sampled"].values
+
+    assert all([0 <= num_hh <= n_shots for num_hh in num_hhs])
+
+
+def test_qv_get_results_by_depth(qvm):
+
+    depths = [2, 3]
+    n_ckts = 10
+    n_shots = 5
+
+    df = generate_quantum_volume_experiments(depths, n_ckts)
+    df = add_programs_to_dataframe(df, qvm)
+    df = acquire_heavy_hitters(df)
+    df = acquire_quantum_volume_data(df, qvm, n_shots)
+    results = get_results_by_depth(df)
+
+    assert len(results.keys()) == len(depths)
+    assert [0 <= results[d][1] <= results[d][0] <= 1 for d in depths]


### PR DESCRIPTION
The data frame organization allows for clearer separation between program generation, classical simulation, and data acquisition which provides more information to the user, e.g. how long each step takes. Externally classically processing the circuit generation and program synthesis steps also allows for higher frequency quantum data collection, especially for large depths. 

Hopefully the API matches that of RB, RPE, and qubit spectroscopy as far as handling of data frames goes.