### PR TITLE
Fix refs

### DIFF
--- a/forest/benchmarking/dfe.py
+++ b/forest/benchmarking/dfe.py
@@ -367,7 +367,7 @@ def aggregate_state_dfe(data: dict):
 
 
 def ratio_variance(a: np.ndarray, var_a: np.ndarray, b: np.ndarray, var_b: np.ndarray) -> np.ndarray:
-    """
+    r"""
     Given random variables 'A' and 'B', compute the variance on the ratio Y = A/B. Denote the
     mean of the random variables as a = E[A] and b = E[B] while the variances are var_a = Var[A]
     and var_b = Var[B] and the covariance as Cov[A,B]. The following expression approximates the

--- a/forest/benchmarking/dfe.py
+++ b/forest/benchmarking/dfe.py
@@ -93,12 +93,16 @@ def exhaustive_process_dfe(program: Program, qubits: list,
     The algorithm is due to:
 
     [DFE1]  Practical Characterization of Quantum Devices without Tomography
-            Silva et al., PRL 107, 210404 (2011)
+            Silva et al.,
+            PRL 107, 210404 (2011)
             https://doi.org/10.1103/PhysRevLett.107.210404
+            https://arxiv.org/abs/1104.3835
 
     [DFE2]  Direct Fidelity Estimation from Few Pauli Measurements
-            Flammia and Liu, PRL 106, 230501 (2011)
+            Flammia et al.,
+            PRL 106, 230501 (2011)
             https://doi.org/10.1103/PhysRevLett.106.230501
+            https://arxiv.org/abs/1104.4695
 
     :param program: A program comprised of clifford gates that defines the process for
         which we estimate the fidelity.
@@ -124,12 +128,16 @@ def exhaustive_state_dfe(program: Program, qubits: list,
     The algorithm is due to:
 
     [DFE1]  Practical Characterization of Quantum Devices without Tomography
-            Silva et al., PRL 107, 210404 (2011)
+            Silva et al.,
+            PRL 107, 210404 (2011)
             https://doi.org/10.1103/PhysRevLett.107.210404
+            https://arxiv.org/abs/1104.3835
 
     [DFE2]  Direct Fidelity Estimation from Few Pauli Measurements
-            Flammia and Liu, PRL 106, 230501 (2011)
+            Flammia et al.,
+            PRL 106, 230501 (2011)
             https://doi.org/10.1103/PhysRevLett.106.230501
+            https://arxiv.org/abs/1104.4695
 
     :param program: A program comprised of clifford gates that constructs a state
         for which we estimate the fidelity.
@@ -207,16 +215,7 @@ def acquire_dfe_data(experiment, quantum_machine: QuantumComputer, var: float = 
 
     This leads to a quadratic reduction in overhead wrt state tomography for fidelity estimation.
 
-    The algorithm is due to:
-
-    [DFE1]  Practical Characterization of Quantum Devices without Tomography
-            Silva et al., PRL 107, 210404 (2011)
-            https://doi.org/10.1103/PhysRevLett.107.210404
-
-    [DFE2]  Direct Fidelity Estimation from Few Pauli Measurements
-            Flammia and Liu, PRL 106, 230501 (2011)
-            https://doi.org/10.1103/PhysRevLett.106.230501
-
+    The algorithm is due to [DFE1] and [DFE2].
 
     :param experiment: namedtuple with fields 'in_pauli', 'program', and 'out_pauli'.
     :param quantum_machine: QPUConnection or QVMConnection object to be used

--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -182,10 +182,11 @@ def process_fidelity(pauli_lio0: np.ndarray, pauli_lio1: np.ndarray) -> float:
 
     For more information see:
 
-    A simple formula for the average gate fidelity of a quantum dynamical operation
-    M. Nielsen, Physics Letters A 303, 249 (2002)
-    https://doi.org/10.1016/S0375-9601(02)01272-0
-    https://arxiv.org/abs/quant-ph/0205035
+    [GFID] A simple formula for the average gate fidelity of a quantum dynamical operation
+           M. Nielsen,
+           Physics Letters A 303, 249 (2002)
+           https://doi.org/10.1016/S0375-9601(02)01272-0
+           https://arxiv.org/abs/quant-ph/0205035
 
     :param pauli_lio0: A D^2 x D^2 pauli-liouville matrix (where D is the Hilbert space dimension)
     :param pauli_lio1: A D^2 x D^2 pauli-liouville matrix (where D is the Hilbert space dimension)
@@ -206,10 +207,14 @@ def diamond_norm(choi0: np.ndarray, choi1: np.ndarray) -> float:
     trace-preserving (CPTP) superoperators, represented as Choi matrices.
 
     The calculation uses the simplified semidefinite program of Watrous
-    [arXiv:0901.4709](http://arxiv.org/abs/0901.4709). This calculation
-    becomes very slow for 4 or more qubits.
-    [J. Watrous, [Theory of Computing 5, 11, pp. 217-238
-    (2009)](http://theoryofcomputing.org/articles/v005a011/)]
+
+    [CBN] Semidefinite programs for completely bounded norms
+          J. Watrous
+          Theory of Computing 5, 11, pp. 217-238 (2009)
+          http://theoryofcomputing.org/articles/v005a011
+          http://arxiv.org/abs/0901.4709
+
+    This calculation becomes very slow for 4 or more qubits.
 
     :param choi0: A 4^N x 4^N matrix (where N is the number of qubits)
     :param choi1: A 4^N x 4^N matrix (where N is the number of qubits)

--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -103,7 +103,7 @@ def quantum_chernoff_bound(rho, sigma):
 
 
 def hilbert_schmidt_ip(A, B):
-    """
+    r"""
     Computes the Hilbert-Schmidt (HS) inner product between two operators A and B as
         HS = (A|B) = Tr[A^\dagger B]
     where |B) = vec(B) and (A| is the dual vector to |A).

--- a/forest/benchmarking/graph_state.py
+++ b/forest/benchmarking/graph_state.py
@@ -12,10 +12,19 @@ def create_graph_state(graph: nx.Graph, use_pragmas=True):
 
     A graph state involves Hadamarding all your qubits and then applying a CZ for each
     edge in the graph. A graph state and the ability to measure it however you want gives
-    you universal quantum computation. The authoritative references are
+    you universal quantum computation. Some good references are
 
-     - https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.86.5188
-     - https://arxiv.org/abs/quant-ph/0301052
+    [MBQC] A One-Way Quantum Computer
+           Raussendorf et al.,
+           Phys. Rev. Lett. 86, 5188 (2001)
+           https://doi.org/10.1103/PhysRevLett.86.5188
+           https://arxiv.org/abs/quant-ph/0010033
+
+    [MBCS] Measurement-based quantum computation with cluster states
+           Raussendorf et al.,
+           Phys. Rev. A 68, 022312 (2003)
+           https://dx.doi.org/10.1103/PhysRevA.68.022312
+           https://arxiv.org/abs/quant-ph/0301052
 
     Similar to a Bell state / GHZ state, we can try to prepare a graph state and measure
     how well we've done according to expected parities.

--- a/forest/benchmarking/quantum_volume.py
+++ b/forest/benchmarking/quantum_volume.py
@@ -228,8 +228,9 @@ def measure_quantum_volume(qc: QuantumComputer, qubits: Sequence[int] = None,
     returned by this method.
 
             [QVol] Validating quantum computers using randomized model circuits
-            Cross et al., arXiv:1811.12926v1, Nov 2018
-            https://arxiv.org/pdf/1811.12926.pdf
+                   Cross et al.,
+                   arXiv:1811.12926v1  (2018)
+                   https://arxiv.org/abs/1811.12926
 
     :param qc: the quantum resource whose volume you wish to measure
     :param qubits: available qubits on which to act during measurement. Default all qubits in qc.

--- a/forest/benchmarking/quantum_volume.py
+++ b/forest/benchmarking/quantum_volume.py
@@ -227,10 +227,10 @@ def measure_quantum_volume(qc: QuantumComputer, qubits: Sequence[int] = None,
     extract_quantum_volume_from_results for obtaining the quantum volume from the results
     returned by this method.
 
-            [QVol] Validating quantum computers using randomized model circuits
-                   Cross et al.,
-                   arXiv:1811.12926v1  (2018)
-                   https://arxiv.org/abs/1811.12926
+    [QVol] Validating quantum computers using randomized model circuits
+           Cross et al.,
+           arXiv:1811.12926v1  (2018)
+           https://arxiv.org/abs/1811.12926
 
     :param qc: the quantum resource whose volume you wish to measure
     :param qubits: available qubits on which to act during measurement. Default all qubits in qc.

--- a/forest/benchmarking/random_operators.py
+++ b/forest/benchmarking/random_operators.py
@@ -84,7 +84,7 @@ def ginibre_state_matrix(D, K):
     """
     Given a Hilbert space dimension $D$ and a desired rank $K$, returns
     a D × D positive semidefinite matrix of rank K drawn from the Ginibre ensemble. 
-    For D = K these are staes drawn from the Hilbert-Schmidt measure.
+    For D = K these are states drawn from the Hilbert-Schmidt measure.
 
     See reference [IM] for more details.
 
@@ -94,7 +94,6 @@ def ginibre_state_matrix(D, K):
     """
     if K > D:
         raise ValueError("The rank of the state matrix cannot exceed the dimension.")
-        return
 
     A = ginibre_matrix_complex(D, K)
     M = A.dot(np.transpose(np.conjugate(A)))
@@ -104,17 +103,17 @@ def ginibre_state_matrix(D, K):
 def bures_measure_state_matrix(D):
     """
     Given a Hilbert space dimension $D$, returns a D × D positive 
-    semidefinite matrix drawn from the Bures measure. 
-    
-    :param D: Hilbert space dimension (scalar).
-    :param K: The rank of a state (scalar).
-    :return: Returns a D × K matrix, drawn from the Ginibre ensemble.
-    
+    semidefinite matrix drawn from the Bures measure.
+
     [OSZ] Random Bures mixed states and the distribution of their purity
           Osipov et al.,
           J. Phys. A: Math. Theor. 43, 055302 (2010).
           https://doi.org/10.1088/1751-8113/43/5/055302
           https://arxiv.org/abs/0909.5094
+    
+    :param D: Hilbert space dimension (scalar).
+    :param K: The rank of a state (scalar).
+    :return: Returns a D × K matrix, drawn from the Ginibre ensemble.
     """
     A = ginibre_matrix_complex(D, D)
     U = haar_rand_unitary(D)
@@ -130,16 +129,16 @@ def rand_map_with_BCSZ_dist(D, K):
     Given a Hilbert space dimension $D$ and a Kraus rank $K$, returns a
     $D^2 × D^2$ Choi matrix $J(Λ)$ of a channel drawn from the BCSZ distribution 
     with Kraus rank $K$.
-    
-    :param D: Hilbert space dimension (scalar).
-    :param K: The rank of a state (scalar).
-    :return: D^2 × D^2 Choi matrix, drawn from the BCSZ distribution with Kraus rank K.    
 
     [RQO] Random quantum operations,
           Bruzda et al.,
           Physics Letters A 373, 320 (2009).
           https://doi.org/10.1016/j.physleta.2008.11.043
           https://arxiv.org/abs/0804.2361
+    
+    :param D: Hilbert space dimension (scalar).
+    :param K: The rank of a state (scalar).
+    :return: D^2 × D^2 Choi matrix, drawn from the BCSZ distribution with Kraus rank K.
     """
     # TODO: this ^^ is CPTP, might want a flag that allows for just CP quantum operations.
     # TODO: we now have a partial trace in utils.py  replace below with that...

--- a/forest/benchmarking/random_operators.py
+++ b/forest/benchmarking/random_operators.py
@@ -1,6 +1,13 @@
-"""A module for generating random quantum states and processes. Pseudocode for many of these
-routines can be found in the appendix of the paper by Granade, Combes, and Cory (2016).
-https://arxiv.org/pdf/1509.03770.pdf"""
+"""A module for generating random quantum states and processes.
+
+Pseudocode for many of these routines can be found in the appendix of the paper:
+
+[BAYES] Practical Bayesian Tomography
+        Granade et al.,
+        New Journal of Physics 18, 033024 (2016)
+        https://dx.doi.org/10.1088/1367-2630/18/3/033024
+        https://arxiv.org/abs/1509.03770
+"""
 from typing import Optional
 
 import numpy as np
@@ -15,10 +22,11 @@ def ginibre_matrix_complex(D, K, rs: Optional[RandomState] = None):
     Given a scalars $D$ and $K$, returns a D × K matrix, 
     drawn from the complex Ginibre ensemble, i.e. (N(0, 1) + i · N(0, 1)).
 
-    See: Induced measures in the space of mixed quantum states,
-         Zyczkowski and Sommers,
-         J. Phys A: Math. and Gen. 34, 7111 (2001).
+    [IM] Induced measures in the space of mixed quantum states
+         Zyczkowski et al.,
+         J. Phys A: Math. and Gen. 34, 7111 (2001)
          https://doi.org/10.1088/0305-4470/34/35/335
+         https://arxiv.org/abs/quant-ph/0012101
 
     :param D: Hilbert space dimension (scalar).
     :param K: Ultimately becomes the rank of a state (scalar).
@@ -38,10 +46,11 @@ def haar_rand_unitary(dim, rs=None):
 
     The error is of order 10^-16.
 
-    See: How to generate random matrices from the classical compact groups,
-         Mezzadri,
-         Notices of the American Mathematical Society 54, 592 (2007).
-         http://www.ams.org/notices/200705/fea-mezzadri-web.pdf
+    [MEZ] How to generate random matrices from the classical compact groups
+          Mezzadri
+          Notices of the American Mathematical Society 54, 592 (2007).
+          http://www.ams.org/notices/200705/fea-mezzadri-web.pdf
+          https://arxiv.org/abs/math-ph/0609050
 
     :param dim: Hilbert space dimension (scalar).
     :param rs: Optional random state
@@ -75,17 +84,13 @@ def ginibre_state_matrix(D, K):
     """
     Given a Hilbert space dimension $D$ and a desired rank $K$, returns
     a D × D positive semidefinite matrix of rank K drawn from the Ginibre ensemble. 
-    For D = K these are staes drawn from the Hilbert-Schmidt measure. 
+    For D = K these are staes drawn from the Hilbert-Schmidt measure.
+
+    See reference [IM] for more details.
 
     :param D: Hilbert space dimension (scalar).
     :param K: The rank of a state (scalar).
     :return: Returns a D × K matrix, drawn from the Ginibre ensemble.
-    
-    See: Induced measures in the space of mixed quantum states, 
-         Zyczkowski and Sommers,
-         J. Phys A: Math. and Gen. 34, 7111 (2001).
-         https://doi.org/10.1088/0305-4470/34/35/335
-
     """
     if K > D:
         raise ValueError("The rank of the state matrix cannot exceed the dimension.")
@@ -105,11 +110,11 @@ def bures_measure_state_matrix(D):
     :param K: The rank of a state (scalar).
     :return: Returns a D × K matrix, drawn from the Ginibre ensemble.
     
-    See: Random Bures mixed states and the distribution of their purity,
-         Osipov, Sommers, and Zyczkowski, 
-         J. Phys. A: Math. Theor. 43, 055302 (2010).
-         https://doi.org/10.1088/1751-8113/43/5/055302    
-  
+    [OSZ] Random Bures mixed states and the distribution of their purity
+          Osipov et al.,
+          J. Phys. A: Math. Theor. 43, 055302 (2010).
+          https://doi.org/10.1088/1751-8113/43/5/055302
+          https://arxiv.org/abs/0909.5094
     """
     A = ginibre_matrix_complex(D, D)
     U = haar_rand_unitary(D)
@@ -129,16 +134,15 @@ def rand_map_with_BCSZ_dist(D, K):
     :param D: Hilbert space dimension (scalar).
     :param K: The rank of a state (scalar).
     :return: D^2 × D^2 Choi matrix, drawn from the BCSZ distribution with Kraus rank K.    
-    
-    
-    See: Random quantum operations, 
-         Bruzda, Cappellini, Sommers, and Zyczkowski, 
-         Physics Letters A 373, 320 (2009).
-         https://doi.org/10.1016/j.physleta.2008.11.043
-         
+
+    [RQO] Random quantum operations,
+          Bruzda et al.,
+          Physics Letters A 373, 320 (2009).
+          https://doi.org/10.1016/j.physleta.2008.11.043
+          https://arxiv.org/abs/0804.2361
     """
     # TODO: this ^^ is CPTP, might want a flag that allows for just CP quantum operations.
-
+    # TODO: we now have a partial trace in utils.py  replace below with that...
     X = ginibre_matrix_complex(D ** 2, K)
     rho = X.dot(np.transpose(np.conjugate(X)))
     # Now compute the partial trace using method from:
@@ -169,7 +173,13 @@ def permute_tensor_factors(D, perm):
             Returns the SWAP operator on two qubits which
             maps A_1 \otimes A_2 --> A_2 \otimes A_1.
 
-    See: Equations 5.11, 5.12, and 5.13 in https://arxiv.org/pdf/0711.1017.pdf
+    See: Equations 5.11, 5.12, and 5.13 in
+
+    [SCOTT] Optimizing quantum process tomography with unitary 2-designs
+            A. J. Scott,
+            J. Phys. A 41, 055308 (2008)
+            https://dx.doi.org/10.1088/1751-8113/41/5/055308
+            https://arxiv.org/abs/0711.1017
 
     This function is used in tests for other functions. However, it can also be useful when
     thinking about higher moment (N>2) integrals over the Haar measure.

--- a/forest/benchmarking/rb.py
+++ b/forest/benchmarking/rb.py
@@ -27,6 +27,20 @@ def rb_dataframe(rb_type: str, subgraph: List[Tuple], depths: List[int],
     """
     Generate and return a DataFrame to characterize an RB or unitarity measurement.
 
+    For standard RB see
+    [RB] Scalable and Robust Randomized Benchmarking of Quantum Processes
+         Magesan et al.,
+         Phys. Rev. Lett. 106, 180504 (2011)
+         https://dx.doi.org/10.1103/PhysRevLett.106.180504
+         https://arxiv.org/abs/1009.3639
+
+    Unitarity algorithm is due to
+    [ECN]  Estimating the Coherence of Noise
+           Wallman et al.,
+           New Journal of Physics 17, 113020 (2015)
+           https://dx.doi.org/10.1088/1367-2630/17/11/113020
+           https://arxiv.org/abs/1503.07865
+
     :param rb_type: Label saying which type of RB measurement we're running
     :param subgraph: List of tuples, where each tuple specifies a single qubit or pair of qubits on
          which to run RB. If the length of this list is >1 then we are running simultaneous RB.
@@ -53,13 +67,6 @@ def rb_dataframe(rb_type: str, subgraph: List[Tuple], depths: List[int],
 
 def add_sequences_to_dataframe(df: DataFrame, bm: BenchmarkConnection, random_seed: int = None, interleaved_gate: Program = None):
     """
-        For reference, see
-        [RB] Scalable and Robust Randomized Benchmarking of Quantum Processes
-             Magesan et al.,
-             Phys. Rev. Lett. 106, 180504 (2011)
-             https://dx.doi.org/10.1103/PhysRevLett.106.180504
-             https://arxiv.org/abs/1009.3639
-
     Generates a new random sequence for each row in the measurement DataFrame and adds these to a
     copy of the DataFrame. Returns the new DataFrame.
 
@@ -245,15 +252,10 @@ def strip_inverse_from_sequences(df: DataFrame):
 
 def add_unitarity_sequences_to_dataframe(df: DataFrame, bm: BenchmarkConnection, random_seed: int = None):
     """
-    Unitarity algorithm is due to:
-        [ECN]  Estimating the Coherence of Noise
-               Wallman et al.,
-               New Journal of Physics 17, 113020 (2015)
-               https://dx.doi.org/10.1088/1367-2630/17/11/113020
-               https://arxiv.org/abs/1503.07865
-
     Generates a new random unitarity sequence for each row in the measurement DataFrame and adds
-    these to a copy of the DataFrame. A unitarity sequence of depth D is a standard RB sequence
+    these to a copy of the DataFrame.
+
+    A unitarity sequence of depth D is a standard RB sequence
     of depth D+1 with the last (inversion) gate stripped. Returns the new DataFrame.
     """
     new_df = df.copy()
@@ -296,7 +298,9 @@ def run_unitarity_measurement(df: DataFrame, qc: QuantumComputer, num_trials: in
 
 def unitarity_to_RB_decay(unitarity, dimension):
     """
-    This allows comparison of measured unitarity and RB decays. This function provides an upper bound on the
+    This allows comparison of measured unitarity and RB decays.
+
+    This function provides an upper bound on the
     RB decay given the input unitarity, where the upperbound is saturated when no unitary errors are present,
     e.g. in the case of depolarizing noise. For more, see Proposition 8. in [ECN]
         unitarity >= (1-dr/(d-1))^2
@@ -596,17 +600,17 @@ def interleaved_gate_fidelity_bounds(irb_decay, rb_decay, dim, unitarity = None)
     Optionally, use unitarity measurement result to provide improved bounds on the interleaved gate's fidelity.
 
     Bounds due to
-        [IRB] Efficient measurement of quantum gate error by interleaved randomized benchmarking
-              Magesan et al.,
-              Phys. Rev. Lett. 109, 080505 (2012)
-              https://dx.doi.org/10.1103/PhysRevLett.109.080505
-              https://arxiv.org/abs/1203.4550
+    [IRB] Efficient measurement of quantum gate error by interleaved randomized benchmarking
+          Magesan et al.,
+          Phys. Rev. Lett. 109, 080505 (2012)
+          https://dx.doi.org/10.1103/PhysRevLett.109.080505
+          https://arxiv.org/abs/1203.4550
 
-    Improved bounds using unitarity due to:
-        [U+IRB]  Efficiently characterizing the total error in quantum circuits
-                 Dugas et al.,
-                 arXiv:1610.05296 (2016)
-                 https://arxiv.org/abs/1610.05296
+    Improved bounds using unitarity due to
+    [U+IRB]  Efficiently characterizing the total error in quantum circuits
+             Dugas et al.,
+             arXiv:1610.05296 (2016)
+             https://arxiv.org/abs/1610.05296
 
     :param irb_decay: Observed decay parameter in irb experiment with desired gate interleaved between Cliffords
     :param rb_decay: Observed decay parameter in standard rb experiment

--- a/forest/benchmarking/rb.py
+++ b/forest/benchmarking/rb.py
@@ -55,8 +55,10 @@ def add_sequences_to_dataframe(df: DataFrame, bm: BenchmarkConnection, random_se
     """
         For reference, see
         [RB] Scalable and Robust Randomized Benchmarking of Quantum Processes
-        Magesan et al., PRL 106, 180504 (2011)
-        arXiv:1009.3639
+             Magesan et al.,
+             Phys. Rev. Lett. 106, 180504 (2011)
+             https://dx.doi.org/10.1103/PhysRevLett.106.180504
+             https://arxiv.org/abs/1009.3639
 
     Generates a new random sequence for each row in the measurement DataFrame and adds these to a
     copy of the DataFrame. Returns the new DataFrame.
@@ -245,8 +247,10 @@ def add_unitarity_sequences_to_dataframe(df: DataFrame, bm: BenchmarkConnection,
     """
     Unitarity algorithm is due to:
         [ECN]  Estimating the Coherence of Noise
-            Wallman et al., New Journal of Physics 17, 113020 (2015)
-            arXiv:1503.07865
+               Wallman et al.,
+               New Journal of Physics 17, 113020 (2015)
+               https://dx.doi.org/10.1088/1367-2630/17/11/113020
+               https://arxiv.org/abs/1503.07865
 
     Generates a new random unitarity sequence for each row in the measurement DataFrame and adds
     these to a copy of the DataFrame. A unitarity sequence of depth D is a standard RB sequence
@@ -593,13 +597,16 @@ def interleaved_gate_fidelity_bounds(irb_decay, rb_decay, dim, unitarity = None)
 
     Bounds due to
         [IRB] Efficient measurement of quantum gate error by interleaved randomized benchmarking
-            Magesan et al., Physical Review Letters 109, 080505 (2012)
-            arXiv:1203.4550
+              Magesan et al.,
+              Phys. Rev. Lett. 109, 080505 (2012)
+              https://dx.doi.org/10.1103/PhysRevLett.109.080505
+              https://arxiv.org/abs/1203.4550
 
     Improved bounds using unitarity due to:
         [U+IRB]  Efficiently characterizing the total error in quantum circuits
-            Dugas, Wallman, and Emerson (2016)
-            arXiv:1610.05296v2
+                 Dugas et al.,
+                 arXiv:1610.05296 (2016)
+                 https://arxiv.org/abs/1610.05296
 
     :param irb_decay: Observed decay parameter in irb experiment with desired gate interleaved between Cliffords
     :param rb_decay: Observed decay parameter in standard rb experiment

--- a/forest/benchmarking/rpe.py
+++ b/forest/benchmarking/rpe.py
@@ -61,7 +61,7 @@ def generate_single_depth_experiment(rotation: Program, depth: int, exp_type: st
 
 def generate_2q_single_depth_experiment(rotation: Program, depth: int, exp_type: str,
                                         measurement_qubit: int, init_one: bool = False, axis: Tuple = None) -> Program:
-    """
+    r"""
     A special variant of the 1q method that is specifically designed to calibrate a CPHASE gate. The
     ideal CPHASE is of the following form
         CPHASE(\phi) = diag(1,1,1,Exp[-i \phi]

--- a/forest/benchmarking/rpe.py
+++ b/forest/benchmarking/rpe.py
@@ -111,12 +111,16 @@ def generate_rpe_experiments(rotation: Program, num_depths: int = 5, axis: Tuple
     The algorithm is due to:
 
     [RPE]  Robust Calibration of a Universal Single-Qubit Gate-Set via Robust Phase Estimation
-            Kimmel et al., Phys. Rev. A 92, 062315 (2015)
-            https://doi.org/10.1103/PhysRevA.92.062315
+           Kimmel et al.,
+           Phys. Rev. A 92, 062315 (2015)
+           https://doi.org/10.1103/PhysRevA.92.062315
+           https://arxiv.org/abs/1502.02677
 
     [RPE2] Experimental Demonstration of a Cheap and Accurate Phase Estimation
-            Rudinger et al., Phys. Rev. Lett. 118, 190502 (2017)
-            https://doi.org/10.1103/PhysRevLett.118.190502
+           Rudinger et al.,
+           Phys. Rev. Lett. 118, 190502 (2017)
+           https://doi.org/10.1103/PhysRevLett.118.190502
+           https://arxiv.org/abs/1702.01763
 
     :param rotation: the program or gate whose angle of rotation is to be estimated
     :param num_depths: the number of depths in the protocol described in [RPE]. Max depth = 2**(num_depths-1)

--- a/forest/benchmarking/superop_conversion.py
+++ b/forest/benchmarking/superop_conversion.py
@@ -5,7 +5,25 @@ We have arbitrarily decided to use a column stacking convention.
 For more information about the conventions used, look at the file in
 /docs/Superoperator representations.md
 
-Further references include: arXiv:1111.6950, arXiv:quant-ph/0504091, arXiv:quant-ph/0401119
+Further references include:
+
+[GRAPTN] Tensor networks and graphical calculus for open quantum systems
+         Wood et al.
+         Quant. Inf. Comp. 15, 0579-0811 (2015)
+         (no DOI)
+         https://arxiv.org/abs/1111.6950
+
+[MATQO] On the Matrix Representation of Quantum Operations
+        Nambu et al.,
+        arXiv: 0504091 (2005)
+        https://arxiv.org/abs/quant-ph/0504091
+
+[DUAL] On duality between quantum maps and quantum states
+       Zyczkowski et al.,
+       Open Syst. Inf. Dyn. 11, 3 (2004)
+       https://dx.doi.org/10.1023/B:OPSY.0000024753.05661.c2
+       https://arxiv.org/abs/quant-ph/0401119
+
 """
 import numpy as np
 from forest.benchmarking.utils import n_qubit_pauli_basis

--- a/forest/benchmarking/superop_conversion.py
+++ b/forest/benchmarking/superop_conversion.py
@@ -65,7 +65,7 @@ def unvec(vector):
 
 
 def kraus2superop(kraus_ops: list):
-    """
+    r"""
     Convert a set of Kraus operators (representing a channel) to
     a superoperator using the column stacking convention.
 
@@ -106,7 +106,7 @@ def kraus2pauli_liouville(kraus_ops: list):
 
 
 def kraus2choi(kraus_ops: list):
-    """
+    r"""
     Convert a set of Kraus operators (representing a channel) to
     a Choi matrix using the column stacking convention.
 

--- a/forest/benchmarking/tomography.py
+++ b/forest/benchmarking/tomography.py
@@ -586,10 +586,13 @@ def _constraint_project(choi_mat, trace_preserving=True):
     """
     Projects the given Choi matrix into the subspace of Completetly Positive and either Trace Perserving (TP) or
     Trace-Non-Increasing maps.
-    Uses Dykstra's algorithm witht the stopping criterion presented in
-        E. G. Birgin and M. Raydan, Dykstra’s algorithm and robust
-        stopping criteria (Springer US, Boston, MA, 2009),
-        pp. 828–833, ISBN 978-0-387-74759-0.
+    Uses Dykstra's algorithm with the stopping criterion presented in:
+
+    [DYKALG] Dykstra’s algorithm and robust stopping criteria
+             Birgin et al.,
+             (Springer US, Boston, MA, 2009), pp. 828–833, ISBN 978-0-387-74759-0.
+             https://doi.org/10.1007/978-0-387-74759-0_143
+
     This method is suggested in [PGD]
 
     :param choi_mat: A density matrix corresponding to the Choi representation estimate of a quantum process.

--- a/forest/benchmarking/tomography.py
+++ b/forest/benchmarking/tomography.py
@@ -777,10 +777,12 @@ def project_density_matrix(rho) -> np.ndarray:
 
     This is the so called "wizard" method. It is described in the following reference:
 
-    Smolin et al., Efficient Method for Computing the Maximum-Likelihood Quantum State from
-    Measurements with Additive Gaussian Noise
-    Phys. Rev. Lett. 108, 070502 (2012)
-    https://doi.org/10.1103/PhysRevLett.108.070502
+    [MLEWIZ] Efficient Method for Computing the Maximum-Likelihood Quantum State from
+             Measurements with Additive Gaussian Noise
+             Smolin et al.,
+             Phys. Rev. Lett. 108, 070502 (2012)
+             https://doi.org/10.1103/PhysRevLett.108.070502
+             https://arxiv.org/abs/1106.5458
 
     :param rho: Numpy array containing the density matrix with dimension (N, N)
     :return rho_projected: The closest positive semi-definite trace 1 matrix to rho.

--- a/forest/benchmarking/tomography.py
+++ b/forest/benchmarking/tomography.py
@@ -321,10 +321,10 @@ def linear_inv_state_estimate(results: List[ExperimentResult],
     see https://en.wikipedia.org/wiki/Quantum_tomography#Linear_inversion or
     see section 3.4 of
 
-        Initialization and characterization of open quantum systems
-        C. Wood, PhD thesis from University of Waterloo, (2015).
-        http://hdl.handle.net/10012/9557
-
+    [WOOD] Initialization and characterization of open quantum systems
+           C. Wood,
+           PhD thesis from University of Waterloo, (2015).
+           http://hdl.handle.net/10012/9557
 
     :param results: A tomographically complete list of results.
     :param qubits: All qubits that were tomographized. This specifies the order in
@@ -386,17 +386,17 @@ def iterative_mle_state_estimate(results: List[ExperimentResult], qubits: List[i
              https://doi.org/10.1103/PhysRevLett.107.020404
              https://arxiv.org/abs/1102.2662
                 
-    [HMLE] Hedged Maximum Likelihood Quantum State Estimation
-           Blume-Kohout,
-           PRL, 105, 200504 (2010)
-           https://doi.org/10.1103/PhysRevLett.105.200504
-           https://arxiv.org/abs/1001.2029
+    [HMLE]   Hedged Maximum Likelihood Quantum State Estimation
+             Blume-Kohout,
+             PRL, 105, 200504 (2010)
+             https://doi.org/10.1103/PhysRevLett.105.200504
+             https://arxiv.org/abs/1001.2029
 
-    [IHMLE] Iterative Hedged MLE from Yong Siah Teo's PhD thesis, see Eqn. 1.5.13 on page 88:
-            Numerical Estimation Schemes for Quantum Tomography
-            Teo
-            PhD Thesis, National University of Singapore, (2013)
-            https://arxiv.org/pdf/1302.3399.pdf
+    [IHMLE]  Iterative Hedged MLE from Yong Siah Teo's PhD thesis, see Eqn. 1.5.13 on page 88:
+             Numerical Estimation Schemes for Quantum Tomography
+             Y. S. Teo
+             PhD Thesis, from National University of Singapore, (2013)
+             https://arxiv.org/pdf/1302.3399.pdf
 
     :param state_tomography_experiment_data data: namedtuple.
     :param dilution: delta  = 1 / epsilon where epsilon is the dilution parameter used in [DIMLE1].

--- a/forest/benchmarking/tomography.py
+++ b/forest/benchmarking/tomography.py
@@ -372,25 +372,31 @@ def iterative_mle_state_estimate(results: List[ExperimentResult], qubits: List[i
     
     The basic algorithm is due to
     
-    [DIMLE1]    Diluted maximum-likelihood algorithm for quantum tomography
-                Řeháček et al., PRA 75, 042108 (2007)
-                https://doi.org/10.1103/PhysRevA.75.042108
+    [DIMLE1] Diluted maximum-likelihood algorithm for quantum tomography
+             Řeháček et al.,
+             PRA 75, 042108 (2007)
+             https://doi.org/10.1103/PhysRevA.75.042108
+             https://arxiv.org/abs/quant-ph/0611244
 
     with improvements from
 
-    [DIMLE2]    Quantum-State Reconstruction by Maximizing Likelihood and Entropy
-                Teo et al., PRL 107, 020404 (2011)
-                https://doi.org/10.1103/PhysRevLett.107.020404
+    [DIMLE2] Quantum-State Reconstruction by Maximizing Likelihood and Entropy
+             Teo et al.,
+             PRL 107, 020404 (2011)
+             https://doi.org/10.1103/PhysRevLett.107.020404
+             https://arxiv.org/abs/1102.2662
                 
-    [HMLE]      Hedged Maximum Likelihood Quantum State Estimation
-                Blume-Kohout, PRL, 105, 200504 (2010)
-                https://doi.org/10.1103/PhysRevLett.105.200504
+    [HMLE] Hedged Maximum Likelihood Quantum State Estimation
+           Blume-Kohout,
+           PRL, 105, 200504 (2010)
+           https://doi.org/10.1103/PhysRevLett.105.200504
+           https://arxiv.org/abs/1001.2029
 
-    [IHMLE]     Iterative Hedged MLE from Yong Siah Teo's PhD thesis:
-                Numerical Estimation Schemes for Quantum Tomography
-                https://arxiv.org/pdf/1302.3399.pdf
-                See Eqn. 1.5.13 on page 88.
-                
+    [IHMLE] Iterative Hedged MLE from Yong Siah Teo's PhD thesis, see Eqn. 1.5.13 on page 88:
+            Numerical Estimation Schemes for Quantum Tomography
+            Teo
+            PhD Thesis, National University of Singapore, (2013)
+            https://arxiv.org/pdf/1302.3399.pdf
 
     :param state_tomography_experiment_data data: namedtuple.
     :param dilution: delta  = 1 / epsilon where epsilon is the dilution parameter used in [DIMLE1].

--- a/forest/benchmarking/tomography.py
+++ b/forest/benchmarking/tomography.py
@@ -684,9 +684,11 @@ def pgdb_process_estimate(results: List[ExperimentResult], qubits: List[int],
     """
     Provide an estimate of the process via Projected Gradient Descent with Backtracking.
 
-        [PGD] Maximum-likelihood quantum process tomography via projected gradient descent
-        Knee, Bolduc, Leach, and Gauger. (2018)
-        arXiv:1803.10062
+    [PGD] Maximum-likelihood quantum process tomography via projected gradient descent
+          Knee et al.,
+          Phys. Rev. A 98, 062336 (2018)
+          https://dx.doi.org/10.1103/PhysRevA.98.062336
+          https://arxiv.org/abs/1803.10062
 
     :param results: A tomographically complete list of ExperimentResults
     :param qubits: A list of qubits giving the tensor order of the resulting Choi matrix.

--- a/forest/benchmarking/utils.py
+++ b/forest/benchmarking/utils.py
@@ -65,7 +65,7 @@ def str_to_pauli_term(pauli_str: str, qubit_labels=None):
 
 def local_sic_prep(label, qubit):
     """
-
+    TODO: !
     :param label:
     :param qubit:
     :return:
@@ -400,9 +400,9 @@ def transform_bit_moments_to_pauli(mean_c, var_c):
 
 
 def partial_trace(rho, keep, dims, optimize=False):
-    """Calculate the partial trace.
+    r"""Calculate the partial trace.
 
-    Consider a joint state ρ on the Hilbert space H_a \\otimes H_b. We wish to trace over H_b e.g.
+    Consider a joint state ρ on the Hilbert space H_a \otimes H_b. We wish to trace over H_b e.g.
 
     ρ_a = Tr_b(ρ).
 


### PR DESCRIPTION
See https://github.com/rigetti/forest-benchmarking/issues/64

All refs are fixed with the exception of the ratio_variance in DFE. However that lives in pyQuil and the owners of that repo can deal with it.