### PR TITLE
replace bespoke superoperator conversion in tests & notebook on distance_measures (Issues #71 and #92)

### DIFF
--- a/examples/distance_measures.ipynb
+++ b/examples/distance_measures.ipynb
@@ -194,7 +194,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Diamond norm AKA the completely bounded trace norm"
+    "## Diamond norm distance AKA the completely bounded trace norm"
    ]
   },
   {
@@ -228,21 +228,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def _gate_to_superop(gate):\n",
-    "    dim = gate.shape[0]\n",
-    "    superop = np.outer(gate, gate.conj().T)\n",
-    "    superop = np.reshape(superop, [dim]*4)\n",
-    "    superop = np.transpose(superop, [0, 3, 1, 2])\n",
-    "    return superop\n",
-    "\n",
-    "def _superop_to_choi(superop):\n",
-    "    dim = superop.shape[0]\n",
-    "    superop = np.transpose(superop, (0, 2, 1, 3))\n",
-    "    choi = np.reshape(superop, [dim**2] * 2)\n",
-    "    return choi\n",
-    "\n",
-    "def _gate_to_choi(gate):\n",
-    "    return _superop_to_choi(_gate_to_superop(gate))"
+    "from forest.benchmarking.superoperator_tools import kraus2choi"
    ]
   },
   {
@@ -251,9 +237,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "choi0 = _gate_to_choi(Id) \n",
-    "choi1 = _gate_to_choi(Ud)\n",
-    "choi2 = _gate_to_choi(Xd)"
+    "choi0 = kraus2choi(Id) \n",
+    "choi1 = kraus2choi(Ud)\n",
+    "choi2 = kraus2choi(Xd)"
    ]
   },
   {
@@ -262,7 +248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dnorm = dm.diamond_norm(choi0, choi1)\n",
+    "dnorm = dm.diamond_norm_distance(choi0, choi1)\n",
     "print(\"This gate is close to the identity as the diamond norm is close to zero. Dnorm= \",dnorm)"
    ]
   },
@@ -272,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dnorm = dm.diamond_norm(choi0, choi2)\n",
+    "dnorm = dm.diamond_norm_distance(choi0, choi2)\n",
     "print(\"This gate is far from identity as diamond norm = \",dnorm)"
    ]
   },

--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -263,7 +263,7 @@ def _is_square(n):
 
 
 def watrous_bounds(choi: np.ndarray) -> float:
-    """Return the Watrous bounds for the diamon norm of a superoperator in
+    """Return the Watrous bounds for the diamond norm of a superoperator in
     the Choi representation. If this is applied to the difference of two Choi 
     representations, it yields bounds to the diamond norm distance.
 


### PR DESCRIPTION
Prior to the inclusion of the superoperator module there was some code to convert between some superoperator representations. This PR standardizes it across the repo.

Partial resolution of https://github.com/rigetti/forest-benchmarking/issues/91 and full resolution of https://github.com/rigetti/forest-benchmarking/issues/71