### PR TITLE
use dim in docstrings and code instead of d or D (Issue #92)

### DIFF
--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -240,8 +240,8 @@ def diamond_norm_distance(choi0: np.ndarray, choi1: np.ndarray) -> float:
 
     This calculation becomes very slow for 4 or more qubits.
 
-    :param choi0: A 4^N x 4^N matrix (where N is the number of qubits)
-    :param choi1: A 4^N x 4^N matrix (where N is the number of qubits)
+    :param choi0: A 4**N by 4**N matrix (where N is the number of qubits)
+    :param choi1: A 4**N by 4**N matrix (where N is the number of qubits)
 
     """
     # Kudos: Based on MatLab code written by Marcus P. da Silva
@@ -249,8 +249,8 @@ def diamond_norm_distance(choi0: np.ndarray, choi1: np.ndarray) -> float:
     import cvxpy as cvx
     assert choi0.shape == choi1.shape
     assert choi0.shape[0] == choi1.shape[1]
-    dim2 = choi0.shape[0]
-    dim = int(np.sqrt(dim2))
+    dim_squared = choi0.shape[0]
+    dim = int(np.sqrt(dim_squared))
 
     delta_choi = choi0 - choi1
     delta_choi = (delta_choi.conj().T + delta_choi) / 2  # Enforce Hermiticity
@@ -262,13 +262,13 @@ def diamond_norm_distance(choi0: np.ndarray, choi1: np.ndarray) -> float:
     constraints += [cvx.trace(rho) == 1]
 
     # W must be Hermitian, positive semidefinite
-    W = cvx.Variable([dim2, dim2], complex=True)
+    W = cvx.Variable([dim_squared, dim_squared], complex=True)
     constraints += [W == W.H]
     constraints += [W >> 0]
 
     constraints += [(W - cvx.kron(np.eye(dim), rho)) << 0]
 
-    J = cvx.Parameter([dim2, dim2], complex=True)
+    J = cvx.Parameter([dim_squared, dim_squared], complex=True)
     objective = cvx.Maximize(cvx.real(cvx.trace(J.H * W)))
 
     prob = cvx.Problem(objective, constraints)

--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -294,7 +294,7 @@ def watrous_bounds(choi: np.ndarray) -> float:
     StackOverflow answer, although the results can also be found scattered in 
     the literature.
 
-    :param choi: d1 x d2 matrix (for qubits, di = 4^Ni, where Ni is a number of qubits)
+    :param choi: dim1 by dim2 matrix (for qubits, dimi = 4^Ni, where Ni is a number of qubits)
     """
 
     if len(choi.shape) != 2:

--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -12,19 +12,25 @@ from scipy.optimize import minimize_scalar
 
 def purity(rho, dim_renorm=False):
     """
-    Calculates the purity P of a quantum state.
+    Calculates the purity P = tr[ρ**2] of a quantum state ρ.
 
-    If the dimensional renormalization flag is FALSE (default) then  1/D ≤ P ≤ 1.
+    As stated above lower value of the purity depends on the dimension of ρ's Hilbert space. For
+    some applications this can be undesirable. For this reason we introduce an optional dimensional
+    renormalization flag with the following behavior
+
+    If the dimensional renormalization flag is FALSE (default) then  1/dim ≤ P ≤ 1.
     If the dimensional renormalization flag is TRUE then 0 ≤ P ≤ 1.
 
-    :param rho: Is a D x D positive matrix.
+    where dim is the dimension of ρ's Hilbert space.
+
+    :param rho: Is a dim by dim positive matrix.
     :param dim_renorm: Boolean, default False.
     :return: P the purity of the state.
     """
     if dim_renorm:
-        D = np.shape(rho)[0]
+        dim = np.shape(rho)[0]
         Ptemp = np.trace(np.matmul(rho, rho))
-        P = (D / (D - 1.0)) * (Ptemp - 1.0 / D)
+        P = (dim / (dim - 1.0)) * (Ptemp - 1.0 / dim)
     else:
         P = np.trace(np.matmul(rho, rho))
     return P

--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -217,8 +217,8 @@ def process_fidelity(pauli_lio0: np.ndarray, pauli_lio1: np.ndarray) -> float:
     """
     assert pauli_lio0.shape == pauli_lio1.shape
     assert pauli_lio0.shape[0] == pauli_lio1.shape[1]
-    dim2 = pauli_lio0.shape[0]
-    dim = int(np.sqrt(dim2))
+    dim_squared = pauli_lio0.shape[0]
+    dim = int(np.sqrt(dim_squared))
 
     Fe = np.trace(np.matmul(np.transpose(np.conj(pauli_lio0)), pauli_lio1)) / (dim ** 2)
 

--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -294,7 +294,7 @@ def watrous_bounds(choi: np.ndarray) -> float:
     StackOverflow answer, although the results can also be found scattered in 
     the literature.
 
-    :param choi: dim1 by dim2 matrix (for qubits, dimi = 4^Ni, where Ni is a number of qubits)
+    :param choi: dim1 by dim2 matrix (for qubits, dimi = 4**Ni, where Ni is a number of qubits)
     """
 
     if len(choi.shape) != 2:


### PR DESCRIPTION
This is a continuation of the resolution of the great d vs D vs dim debate.
Basically it was decided that we prefer:
dim over d or D
and
dim_squared over dim2 etc
additionally 
dim by dim over dim x dim 
and 
dim**2 over dim^2