### PR TITLE
Identifying qubits measured in a DFE experiment

### DIFF
--- a/forest/benchmarking/direct_fidelity_estimation.py
+++ b/forest/benchmarking/direct_fidelity_estimation.py
@@ -310,7 +310,7 @@ def acquire_dfe_data(qc: QuantumComputer, expr: TomographyExperiment, n_shots=10
     if mitigate_readout_errors:
         res = list(measure_observables(qc, expr, n_shots=n_shots, active_reset=active_reset))
     else:
-        res = list(measure_observables(qc, expr, n_shots=n_shots, active_reset=active_reset, readout_symmetrize=None,
+        res = list(measure_observables(qc, expr, n_shots=n_shots, active_reset=active_reset, symmetrize_readout=None,
                                        calibrate_readout=None))
 
     # identify the qubits being measured

--- a/forest/benchmarking/direct_fidelity_estimation.py
+++ b/forest/benchmarking/direct_fidelity_estimation.py
@@ -314,7 +314,7 @@ def acquire_dfe_data(qc: QuantumComputer, expr: TomographyExperiment, n_shots=10
                                        calibrate_readout=None))
 
     # identify the qubits being measured
-    qubits = list(set(e[0].out_operator.get_qubits() for e in expr))
+    qubits = list(functools.reduce(lambda x, y: set(x) | set(y), [e[0].out_operator.get_qubits() for e in expr]))
 
     return DFEData(results=res,
                    in_states=[str(e[0].in_state) for e in expr],

--- a/forest/benchmarking/direct_fidelity_estimation.py
+++ b/forest/benchmarking/direct_fidelity_estimation.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pyquil import Program
 from pyquil.api import BenchmarkConnection, QuantumComputer
 from pyquil.operator_estimation import ExperimentResult, ExperimentSetting, TomographyExperiment, \
-    TensorProductState, measure_observables, plusX, minusX, plusY, minusY, plusZ, minusZ
+    TensorProductState, measure_observables, plusX, minusX, plusY, minusY, plusZ, minusZ, _max_weight_operator
 from pyquil.paulis import PauliTerm, sI, sX, sY, sZ
 
 
@@ -313,6 +313,10 @@ def acquire_dfe_data(qc: QuantumComputer, expr: TomographyExperiment, n_shots=10
         res = list(measure_observables(qc, expr, n_shots=n_shots, active_reset=active_reset, readout_symmetrize=None,
                                        calibrate_readout=None))
 
+    # identify the qubits being measured
+    max_weight_op = _max_weight_operator([e[0].out_operator for e in expr])
+    qubits = max_weight_op.get_qubits()
+
     return DFEData(results=res,
                    in_states=[str(e[0].in_state) for e in expr],
                    program=expr.program,
@@ -321,8 +325,8 @@ def acquire_dfe_data(qc: QuantumComputer, expr: TomographyExperiment, n_shots=10
                    pauli_std_err=np.array([r.std_err for r in res]),
                    cal_point_est=np.array([r.calibration_expectation for r in res]),
                    cal_std_err=np.array([r.calibration_std_err for r in res]),
-                   dimension=2**len(expr.qubits),
-                   qubits=expr.qubits)
+                   dimension=2**len(qubits),
+                   qubits=qubits)
 
 
 def estimate_dfe(data: DFEData, kind: str) -> DFEEstimate:

--- a/forest/benchmarking/direct_fidelity_estimation.py
+++ b/forest/benchmarking/direct_fidelity_estimation.py
@@ -314,7 +314,7 @@ def acquire_dfe_data(qc: QuantumComputer, expr: TomographyExperiment, n_shots=10
                                        calibrate_readout=None))
 
     # identify the qubits being measured
-    qubits = list(set(e[0].out_operator for e in expr))
+    qubits = list(set(e[0].out_operator.get_qubits() for e in expr))
 
     return DFEData(results=res,
                    in_states=[str(e[0].in_state) for e in expr],

--- a/forest/benchmarking/direct_fidelity_estimation.py
+++ b/forest/benchmarking/direct_fidelity_estimation.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pyquil import Program
 from pyquil.api import BenchmarkConnection, QuantumComputer
 from pyquil.operator_estimation import ExperimentResult, ExperimentSetting, TomographyExperiment, \
-    TensorProductState, measure_observables, plusX, minusX, plusY, minusY, plusZ, minusZ, _max_weight_operator
+    TensorProductState, measure_observables, plusX, minusX, plusY, minusY, plusZ, minusZ
 from pyquil.paulis import PauliTerm, sI, sX, sY, sZ
 
 
@@ -314,8 +314,7 @@ def acquire_dfe_data(qc: QuantumComputer, expr: TomographyExperiment, n_shots=10
                                        calibrate_readout=None))
 
     # identify the qubits being measured
-    max_weight_op = _max_weight_operator([e[0].out_operator for e in expr])
-    qubits = max_weight_op.get_qubits()
+    qubits = list(set(e[0].out_operator for e in expr))
 
     return DFEData(results=res,
                    in_states=[str(e[0].in_state) for e in expr],

--- a/forest/benchmarking/tests/test_direct_fidelity_estimation.py
+++ b/forest/benchmarking/tests/test_direct_fidelity_estimation.py
@@ -2,7 +2,7 @@ from forest.benchmarking.direct_fidelity_estimation import generate_exhaustive_s
     generate_monte_carlo_state_dfe_experiment, generate_monte_carlo_process_dfe_experiment, acquire_dfe_data, estimate_dfe
 
 from pyquil import Program
-from pyquil.api import BenchmarkConnection, get_qc
+from pyquil.api import BenchmarkConnection
 from pyquil.gates import *
 from pyquil.numpy_simulator import NumpyWavefunctionSimulator
 from pyquil.operator_estimation import _one_q_state_prep

--- a/forest/benchmarking/tests/test_direct_fidelity_estimation.py
+++ b/forest/benchmarking/tests/test_direct_fidelity_estimation.py
@@ -97,12 +97,12 @@ def test_monte_carlo_state_dfe(benchmarker: BenchmarkConnection):
 
 
 def test_acquire_dfe_data(benchmarker: BenchmarkConnection, test_qc):
-    process = Program(X(2), X(3))   # this (Clifford) process acts as identity on qubits 0 and 1
-    texpt = generate_exhaustive_state_dfe_experiment(program=process, qubits=[0, 1], benchmarker=benchmarker)
+    # pick (Clifford) process that acts as identity on qubits 0 and 1
+    process = Program(X(2), X(3))
+    texpt = generate_exhaustive_state_dfe_experiment(program=process,
+                                                     qubits=[0, 1], benchmarker=benchmarker)
     dfe_data = acquire_dfe_data(qc=test_qc, expr=texpt)
     dfe_estimate = estimate_dfe(dfe_data, 'state')
-
-    assert 1 == 2
 
     assert dfe_estimate.dimension == 4
     assert dfe_estimate.qubits == [0, 1]

--- a/forest/benchmarking/tests/test_direct_fidelity_estimation.py
+++ b/forest/benchmarking/tests/test_direct_fidelity_estimation.py
@@ -8,7 +8,7 @@ from pyquil.numpy_simulator import NumpyWavefunctionSimulator
 from pyquil.operator_estimation import _one_q_state_prep
 
 from numpy.testing import assert_almost_equal, assert_allclose
-
+import pytest
 from test_process_tomography import test_qc
 
 def test_exhaustive_state_dfe(benchmarker: BenchmarkConnection):
@@ -95,10 +95,12 @@ def test_monte_carlo_state_dfe(benchmarker: BenchmarkConnection):
         assert_almost_equal(expectation,1.,decimal=7)
 
 
-def test_acquire_dfe_data(benchmarker: BenchmarkConnection, qc=test_qc()):
+@pytest.fixture()
+def test_acquire_dfe_data(benchmarker: BenchmarkConnection, test_qc):
     process = Program(X(0))
     texpt = generate_exhaustive_state_dfe_experiment(program=process, qubits=[0], benchmarker=benchmarker)
-    dfe_data = acquire_dfe_data(qc, texpt)
+    test_qc.make_full()
+    dfe_data = acquire_dfe_data(qc=test_qc, expr=texpt)
     dfe_estimate = estimate_dfe(dfe_data, 'state')
 
     assert dfe_estimate.dimension == 2

--- a/forest/benchmarking/tests/test_direct_fidelity_estimation.py
+++ b/forest/benchmarking/tests/test_direct_fidelity_estimation.py
@@ -11,6 +11,7 @@ from numpy.testing import assert_almost_equal, assert_allclose
 import pytest
 from test_process_tomography import test_qc
 
+
 def test_exhaustive_state_dfe(benchmarker: BenchmarkConnection):
     texpt = generate_exhaustive_state_dfe_experiment(program=Program(X(0), X(1)), qubits=[0, 1],
                                                      benchmarker=benchmarker)

--- a/forest/benchmarking/tests/test_direct_fidelity_estimation.py
+++ b/forest/benchmarking/tests/test_direct_fidelity_estimation.py
@@ -8,8 +8,8 @@ from pyquil.numpy_simulator import NumpyWavefunctionSimulator
 from pyquil.operator_estimation import _one_q_state_prep
 
 from numpy.testing import assert_almost_equal, assert_allclose
-import pytest
 from test_process_tomography import test_qc
+import pytest
 
 
 def test_exhaustive_state_dfe(benchmarker: BenchmarkConnection):
@@ -96,15 +96,15 @@ def test_monte_carlo_state_dfe(benchmarker: BenchmarkConnection):
         assert_almost_equal(expectation,1.,decimal=7)
 
 
-@pytest.fixture()
 def test_acquire_dfe_data(benchmarker: BenchmarkConnection, test_qc):
-    process = Program(X(0))
-    texpt = generate_exhaustive_state_dfe_experiment(program=process, qubits=[0], benchmarker=benchmarker)
-    test_qc.make_full()
+    process = Program(X(2), X(3))   # this (Clifford) process acts as identity on qubits 0 and 1
+    texpt = generate_exhaustive_state_dfe_experiment(program=process, qubits=[0, 1], benchmarker=benchmarker)
     dfe_data = acquire_dfe_data(qc=test_qc, expr=texpt)
     dfe_estimate = estimate_dfe(dfe_data, 'state')
 
-    assert dfe_estimate.dimension == 2
-    assert dfe_estimate.qubits == [0]
+    assert 1 == 2
+
+    assert dfe_estimate.dimension == 4
+    assert dfe_estimate.qubits == [0, 1]
     assert_allclose(dfe_estimate.fid_point_est, 1.0)
     assert_allclose(dfe_estimate.fid_std_err, 0.0)

--- a/forest/benchmarking/tests/test_process_tomography.py
+++ b/forest/benchmarking/tests/test_process_tomography.py
@@ -28,9 +28,6 @@ def test_qc():
 
     class BasicQVMCompiler(AbstractCompiler):
 
-        def __init__(self):
-            self.compiler = self
-
         def quil_to_native_quil(self, program: Program):
             return basic_compile(program)
 

--- a/forest/benchmarking/tests/test_process_tomography.py
+++ b/forest/benchmarking/tests/test_process_tomography.py
@@ -81,6 +81,10 @@ def test_qc():
     from pyquil.gates import I
 
     class BasicQVMCompiler(AbstractCompiler):
+
+        def __init__(self):
+            self.compiler = self
+
         def quil_to_native_quil(self, program: Program):
             return basic_compile(program)
 


### PR DESCRIPTION
PR #107 did not completely remove the dependency on the `qubits` input to `TomographyExperiment` as purported. This left a bug that broke `acquire_dfe_data`. This PR fixes that bug, and adds a test that would've caught it.

EDIT: Additionally, this replaces the (re-named) input `readout_symmetrize` to `symmetrize_readout`, appearing in the call to `measure_observables` inside `acquire_dfe_data`. Presumably, this has so far not triggered a bug since the `mitigate_readout_errors` option is set to `True` by default.