### PR TITLE
Update test fixture after pyquil change.

### DIFF
--- a/forest/benchmarking/tests/conftest.py
+++ b/forest/benchmarking/tests/conftest.py
@@ -18,6 +18,40 @@ RACK_YAML = os.path.join(PATH, "example_rack.yaml")
 
 
 @pytest.fixture(scope='module')
+def test_qc():
+    import networkx as nx
+    from requests.exceptions import RequestException
+    from rpcq.messages import PyQuilExecutableResponse
+    from forest.benchmarking.compilation import basic_compile
+    from pyquil.api import ForestConnection, QuantumComputer, QVM
+    from pyquil.api._compiler import _extract_attribute_dictionary_from_program
+    from pyquil.api._qac import AbstractCompiler
+    from pyquil.device import NxDevice
+    from pyquil.gates import I
+
+    class BasicQVMCompiler(AbstractCompiler):
+
+        def quil_to_native_quil(self, program: Program, protoquil=None):
+            return basic_compile(program)
+
+        def native_quil_to_executable(self, nq_program: Program):
+            return PyQuilExecutableResponse(
+                program=nq_program.out(),
+                attributes=_extract_attribute_dictionary_from_program(nq_program))
+    try:
+        qc = QuantumComputer(
+            name='testing-qc',
+            qam=QVM(connection=ForestConnection(), random_seed=52),
+            device=NxDevice(nx.complete_graph(2)),
+            compiler=BasicQVMCompiler(),
+        )
+        qc.run_and_measure(Program(I(0)), trials=1)
+        return qc
+    except (RequestException, TimeoutError) as e:
+        return pytest.skip("This test requires a running local QVM: {}".format(e))
+
+
+@pytest.fixture(scope='module')
 def qvm():
     try:
         qc = get_qc('9q-square-qvm')

--- a/forest/benchmarking/tests/test_direct_fidelity_estimation.py
+++ b/forest/benchmarking/tests/test_direct_fidelity_estimation.py
@@ -8,7 +8,6 @@ from pyquil.numpy_simulator import NumpyWavefunctionSimulator
 from forest.benchmarking.observable_estimation import _one_q_state_prep
 
 from numpy.testing import assert_almost_equal, assert_allclose
-from test_process_tomography import test_qc
 
 
 def test_exhaustive_state_dfe(benchmarker: BenchmarkConnection):
@@ -75,6 +74,7 @@ def test_monte_carlo_process_dfe(benchmarker: BenchmarkConnection):
         print(setting.in_state, setting.observable)
         expectation = wfnsim.reset().do_program(prog).expectation(setting.observable)
         assert_almost_equal(expectation, 1., decimal=7)
+
 
 def test_monte_carlo_state_dfe(benchmarker: BenchmarkConnection):
     process = Program(H(0), CNOT(0, 1))

--- a/forest/benchmarking/tests/test_process_tomography.py
+++ b/forest/benchmarking/tests/test_process_tomography.py
@@ -29,7 +29,7 @@ def test_qc():
 
     class BasicQVMCompiler(AbstractCompiler):
 
-        def quil_to_native_quil(self, program: Program):
+        def quil_to_native_quil(self, program: Program, protoquil=None):
             return basic_compile(program)
 
         def native_quil_to_executable(self, nq_program: Program):

--- a/forest/benchmarking/tests/test_process_tomography.py
+++ b/forest/benchmarking/tests/test_process_tomography.py
@@ -1,10 +1,6 @@
-import networkx as nx
 import numpy as np
 import pytest
-from requests.exceptions import RequestException
-from rpcq.messages import PyQuilExecutableResponse
 
-from forest.benchmarking.compilation import basic_compile
 from forest.benchmarking.operator_tools.random_operators import haar_rand_unitary
 from forest.benchmarking.operator_tools.superoperator_transformations import kraus2choi
 from forest.benchmarking.tomography import generate_process_tomography_experiment, \
@@ -14,39 +10,8 @@ from forest.benchmarking.observable_estimation import estimate_observables, Expe
     _one_q_state_prep
 from pyquil import Program
 from pyquil import gate_matrices as mat
-from pyquil.api import QVM
 from pyquil.gates import CNOT, X
 from pyquil.numpy_simulator import NumpyWavefunctionSimulator
-
-
-@pytest.fixture
-def test_qc():
-    from pyquil.api import ForestConnection, QuantumComputer
-    from pyquil.api._compiler import _extract_attribute_dictionary_from_program
-    from pyquil.api._qac import AbstractCompiler
-    from pyquil.device import NxDevice
-    from pyquil.gates import I
-
-    class BasicQVMCompiler(AbstractCompiler):
-
-        def quil_to_native_quil(self, program: Program, protoquil=None):
-            return basic_compile(program)
-
-        def native_quil_to_executable(self, nq_program: Program):
-            return PyQuilExecutableResponse(
-                program=nq_program.out(),
-                attributes=_extract_attribute_dictionary_from_program(nq_program))
-    try:
-        qc = QuantumComputer(
-            name='testing-qc',
-            qam=QVM(connection=ForestConnection(), random_seed=52),
-            device=NxDevice(nx.complete_graph(2)),
-            compiler=BasicQVMCompiler(),
-        )
-        qc.run_and_measure(Program(I(0)), trials=1)
-        return qc
-    except (RequestException, TimeoutError) as e:
-        return pytest.skip("This test requires a running local QVM: {}".format(e))
 
 
 def wfn_estimate_observables(n_qubits, tomo_expt: ObservablesExperiment):

--- a/forest/benchmarking/tests/test_state_tomography.py
+++ b/forest/benchmarking/tests/test_state_tomography.py
@@ -1,23 +1,15 @@
-import networkx as nx
 import numpy as np
 import pytest
 from functools import partial
-from requests.exceptions import RequestException
-from forest.benchmarking.compilation import basic_compile
 from forest.benchmarking.operator_tools.random_operators import haar_rand_unitary
 from forest.benchmarking.tomography import generate_state_tomography_experiment, _R, \
     iterative_mle_state_estimate, estimate_variance, linear_inv_state_estimate
-from pyquil.api import ForestConnection, QuantumComputer, QVM
-from pyquil.api._compiler import _extract_attribute_dictionary_from_program
-from pyquil.api._qac import AbstractCompiler
-from pyquil.device import NxDevice
 from pyquil.gates import I, H, CZ
 from pyquil.numpy_simulator import NumpyWavefunctionSimulator
 from forest.benchmarking.observable_estimation import estimate_observables, ExperimentResult, \
     ExperimentSetting, zeros_state, exhaustive_symmetrization, calibrate_observable_estimates
 from pyquil.paulis import sI, sZ, sX
 from pyquil.quil import Program
-from rpcq.messages import PyQuilExecutableResponse
 
 from forest.benchmarking import distance_measures as dm
 
@@ -123,33 +115,9 @@ def test_R_operator_fixed_point_2_qubit():
     np.testing.assert_allclose(actual, P00, atol=1e-12)
 
 
-def get_test_qc(n_qubits):
-    class BasicQVMCompiler(AbstractCompiler):
-        def quil_to_native_quil(self, program: Program, protoquil=None):
-            return basic_compile(program)
-
-        def native_quil_to_executable(self, nq_program: Program):
-            return PyQuilExecutableResponse(
-                program=nq_program.out(),
-                attributes=_extract_attribute_dictionary_from_program(nq_program))
-
-    try:
-        qc = QuantumComputer(
-            name='testing-qc',
-            qam=QVM(connection=ForestConnection(), random_seed=52),
-            device=NxDevice(nx.complete_graph(n_qubits)),
-            compiler=BasicQVMCompiler(),
-        )
-        qc.run_and_measure(Program(I(0)), trials=1)
-        return qc
-    except (RequestException, TimeoutError) as e:
-        return pytest.skip("This test requires a running local QVM: {}".format(e))
-
-
 @pytest.fixture(scope='module')
-def single_q_tomo_fixture():
+def single_q_tomo_fixture(test_qc):
     qubits = [0]
-    qc = get_test_qc(n_qubits=len(qubits))
 
     # Generate random unitary
     u_rand = haar_rand_unitary(2 ** 1, rs=np.random.RandomState(52))
@@ -163,17 +131,16 @@ def single_q_tomo_fixture():
 
     # Get data from QVM
     tomo_expt = generate_state_tomography_experiment(state_prep, qubits)
-    results = list(estimate_observables(qc=qc, obs_expt=tomo_expt, num_shots=500,
+    results = list(estimate_observables(qc=test_qc, obs_expt=tomo_expt, num_shots=500,
                                         symmetrization_method=exhaustive_symmetrization))
-    results = list(calibrate_observable_estimates(qc, results))
+    results = list(calibrate_observable_estimates(test_qc, results))
 
     return results, rho_true
 
 
 @pytest.fixture(scope='module')
-def two_q_tomo_fixture():
+def two_q_tomo_fixture(test_qc):
     qubits = [0, 1]
-    qc = get_test_qc(n_qubits=len(qubits))
 
     # Generate random unitary
     u_rand1 = haar_rand_unitary(2 ** 1, rs=np.random.RandomState(52))
@@ -191,9 +158,9 @@ def two_q_tomo_fixture():
 
     # Get data from QVM
     tomo_expt = generate_state_tomography_experiment(state_prep, qubits)
-    results = list(estimate_observables(qc=qc, obs_expt=tomo_expt, num_shots=500,
+    results = list(estimate_observables(qc=test_qc, obs_expt=tomo_expt, num_shots=500,
                                         symmetrization_method=exhaustive_symmetrization))
-    results = list(calibrate_observable_estimates(qc, results))
+    results = list(calibrate_observable_estimates(test_qc, results))
 
     return results, rho_true
 

--- a/forest/benchmarking/tests/test_state_tomography.py
+++ b/forest/benchmarking/tests/test_state_tomography.py
@@ -125,7 +125,7 @@ def test_R_operator_fixed_point_2_qubit():
 
 def get_test_qc(n_qubits):
     class BasicQVMCompiler(AbstractCompiler):
-        def quil_to_native_quil(self, program: Program):
+        def quil_to_native_quil(self, program: Program, protoquil=None):
             return basic_compile(program)
 
         def native_quil_to_executable(self, nq_program: Program):


### PR DESCRIPTION
Recent pyquil update added an argument `protoquil` to `compiler.quil_to_native_quil`. There is a test fixture that replaces this function and needed to be updated to accept this argument. I further moved the shared test fixture to conftest. 

This is necessary to get the tests passing in the rest of the repo.