### PR TITLE
Fix compiler bug in QV and QPU bug in readout.

### DIFF
--- a/forest/benchmarking/quantum_volume.py
+++ b/forest/benchmarking/quantum_volume.py
@@ -7,7 +7,7 @@ from copy import copy
 
 from pyquil.api import QuantumComputer
 from pyquil.numpy_simulator import NumpyWavefunctionSimulator
-from pyquil.quil import DefGate, Program
+from pyquil.quil import DefGate, Program, Pragma
 from rpcq.messages import TargetDevice
 from rpcq._utils import RPCErrorError
 
@@ -41,7 +41,7 @@ def _naive_program_generator(qc: QuantumComputer, qubits: Sequence[int],
     measure_qubits = qubits[:num_measure_qubits]
 
     # create a simple program that uses the compiler to directly generate 2q gates from the matrices
-    prog = Program()
+    prog = Program(Pragma('INITIAL_REWIRING', ['"PARTIAL"']))
     for layer_idx, (perm, layer) in enumerate(zip(permutations, gates)):
         for gate_idx, gate in enumerate(layer):
             # get the Quil definition for the new gate

--- a/forest/benchmarking/readout.py
+++ b/forest/benchmarking/readout.py
@@ -151,7 +151,8 @@ def estimate_joint_confusion_in_set(qc: QuantumComputer, qubits: Sequence[int] =
 
                 if use_param_program:
                     # specify bitstring in parameterization at run-time
-                    results = qc.run(executable, memory_map={reg_name: bitstring})
+                    results = qc.run(executable,
+                                     memory_map={reg_name: [float(b) for b in bitstring]})
                 else:
                     # generate program that measures given bitstring on group, and append to start
                     bitstring_program = program_start + bitstring_prep(group, bitstring,
@@ -292,7 +293,8 @@ def estimate_joint_reset_confusion(qc: QuantumComputer, qubits: Sequence[int] = 
                     # try preparation at most 10 times.
                     for _ in range(10):
                         # prepare the given bitstring and measure
-                        result = qc.run(prep_executable, memory_map={reg_name: bitstring})
+                        result = qc.run(prep_executable,
+                                        memory_map={reg_name: [float(b) for b in bitstring]})
 
                         # if the preparation is successful, move on to reset.
                         if np.array_equal(result[0], bitstring):


### PR DESCRIPTION
Issue 1 in quantum volume: The compiler needs a partial initial rewiring to prevent failure to compile a 'disconnected' program onto a lattice. While the QVM 

Issue 2 in readout: the QPU requires that parameters are floats. 