### PR TITLE
update bibtex file for fair credit attribuiton

### DIFF
--- a/forest-benchmarking.bib
+++ b/forest-benchmarking.bib
@@ -1,6 +1,7 @@
 @misc{forestbenchmarking,
-  author       = {Joshua Combes and
-                  Kyle Gulshen and
+
+  author       = {Kyle Gulshen and
+                  Joshua Combes and
                   Matthew P. Harrigan and
                   Peter J. Karalekas and
                   Marcus P. da Silva and
@@ -18,6 +19,8 @@
                   Alexa Staley and
                   Nikolas A. Tezak and
                   Joseph Valery},
+  % https://tex.stackexchange.com/questions/468623/indicating-joint-first-authorship-through-special-markup-in-biblatex-biber
+  author+an    = {1=jointfirst; 2=jointfirst},
   title        = {{F}orest {B}enchmarking: {QCVV} using {PyQuil}},
   year         = {2019},
   doi          = {10.5281/zenodo.3455847},


### PR DESCRIPTION
Description
-----------

Hi all. I just noticed that the author order got switched. I changed it back because while I may have made a lot of contributions Kyle has made **very significant** contributions. In any-case we very much worked as a team.

Checklist
---------

- [X] The above description motivates these changes.
- [X] There is a unit test that covers these changes.
- [X] The code respects the API separation discussed in .github/CONTRIBUTING.md.
- [X] Relevant references and equations are cited using our standard reference style.
- [X] All new and existing tests pass locally and on Semaphore.
- [X] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [X] Functions and classes have useful sphinx-style docstrings.
- [-] (New Feature) The docs and example notebooks have been updated accordingly.
- [-] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [-] The changelog (`docs/source/changes.rst`) has a description of this change.
