### PR TITLE
expose XY gate in compilation

### DIFF
--- a/forest/benchmarking/compilation.py
+++ b/forest/benchmarking/compilation.py
@@ -3,7 +3,7 @@ from math import pi
 import numpy as np
 from typing import Tuple
 
-from pyquil.gates import RX, RZ, CZ, I
+from pyquil.gates import RX, RZ, CZ, I, XY
 from pyquil.quil import Program
 from pyquil.quilbase import Gate
 
@@ -212,6 +212,8 @@ def basic_compile(program: Program):
 
             if inst.name == 'CZ':
                 new_prog += CZ(*inst.qubits) # remove dag modifiers
+            elif inst.name == 'XY':
+                new_prog += XY(angle_param, *inst.qubits)
             elif inst.name == 'I':
                 new_prog += I(inst.qubits[0]) # remove dag modifiers
             elif inst.name == 'RZ':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyquil>=2.7.0
+--index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple pyquil==2.13.0.10
 numpy
 networkx
 pandas


### PR DESCRIPTION
Blocked by https://github.com/rigetti/pyquil/pull/1096

Description
-----------

Insert your PR description here. Thanks for contributing to forest Benchmarking! :)

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] The code respects the API separation discussed in .github/CONTRIBUTING.md.
- [ ] Relevant references and equations are cited using our standard reference style.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs and example notebooks have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The changelog (`docs/source/changes.rst`) has a description of this change.
