### PR TITLE
Limit coverage version to less than 5 for nbval compatibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ matplotlib>=3.1.0
 # test dependencies
 flake8
 pytest
-pytest-cov
+pytest-cov<5
 referenceqvm
 requests
 scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ matplotlib>=3.1.0
 # test dependencies
 flake8
 pytest
-pytest-cov<5
+pytest-cov
 referenceqvm
 requests
 scikit-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pytest-cov
 referenceqvm
 requests
 scikit-learn
+coverage<5
 
 # doc dependencies
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=open('README.md').read(),
     install_requires=[
         'pyquil>=2.14.0',
-        'pytest_cov<5'
+        'pytest-cov<5'
         'numpy',
         'networkx',
         'pandas',

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     long_description=open('README.md').read(),
     install_requires=[
         'pyquil>=2.14.0',
+        'pytest_cov<5'
         'numpy',
         'networkx',
         'pandas',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=open('README.md').read(),
     install_requires=[
         'pyquil>=2.14.0',
-        'pytest-cov<5'
+        'coverage<5'
         'numpy',
         'networkx',
         'pandas',


### PR DESCRIPTION
Description
-----------

The tests on example notebooks use nbval which has recently been rendered incompatible with the latest version of pytest-cov. We need to limit the version to get the tests to pass. 

Checklist
---------

- [x] The above description motivates these changes.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The changelog (`docs/source/changes.rst`) has a description of this change.
