### PR TITLE
Increase compiler timeout so tests pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+[v0.7.2](https://github.com/rigetti/forest-benchmarking/compare/v0.7.1...master) (in development)
+------------------------------------------------------------------------------------
+
+### Bugfixes
+
+- Fix compiler timeout during test (@jlapeyre) (gh-208)
+- Fix type error in pauli coefficient in observable calibration for recent pyquil versions (@kylegulshen) (gh-207)
+- Add noise definition only once to quil program (@kylegulshen) (gh-206)
+
+
 v0.7.1 (November 25, 2019)
 --------------------------
 

--- a/forest/benchmarking/tests/conftest.py
+++ b/forest/benchmarking/tests/conftest.py
@@ -53,7 +53,7 @@ def test_qc():
 def qvm():
     try:
         qc = get_qc('9q-square-qvm')
-        qc.compiler.client.timeout = 1
+        qc.compiler.client.timeout = 10
         qc.run_and_measure(Program(I(0)), trials=1)
         return qc
     except (RequestException, TimeoutError) as e:
@@ -89,7 +89,7 @@ def cxn():
 @pytest.fixture(scope='session')
 def benchmarker():
     try:
-        benchmarker = get_benchmarker(timeout=1)
+        benchmarker = get_benchmarker(timeout=10)
         benchmarker.apply_clifford_to_pauli(Program(I(0)), sX(0))
         return benchmarker
     except (RequestException, TimeoutError) as e:


### PR DESCRIPTION
Closes #195

The test suite reports errors due to timeouts communicating with the compiler.
The test suite passes locally with this PR.

Checklist
---------

- [x] The above description motivates these changes.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] (Bugfix) The associated issue is referenced above using
- [x] The changelog (`docs/source/changes.rst`) has a description of this change.
