### PR TITLE
Preserve program metadata during compilation

### DIFF
--- a/forest/benchmarking/compilation.py
+++ b/forest/benchmarking/compilation.py
@@ -190,9 +190,7 @@ def basic_compile(program: Program):
     :return: a program with some of the input non-native quil gates replaced with basic native quil
         gate implementations.
     """
-    new_prog = Program()
-    new_prog.num_shots = program.num_shots
-    new_prog.inst(program.defined_gates)
+    new_prog = program.copy_everything_except_instructions()
 
     daggered_defgates = []
 


### PR DESCRIPTION
Description
-----------

This small change leaves it up to the `Program` object to preserve metadata during `basic_compile`. 

Checklist
---------

- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] The code respects the API separation discussed in .github/CONTRIBUTING.md.
- [ ] Relevant references and equations are cited using our standard reference style.
- [ ] All new and existing tests pass locally and on Semaphore.
- [ ] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [ ] Functions and classes have useful sphinx-style docstrings.
- [ ] (New Feature) The docs and example notebooks have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [ ] The changelog (`docs/source/changes.rst`) has a description of this change.
