### PR TITLE
set random seed for rb experiment sequences

### DIFF
--- a/forest/benchmarking/tests/test_randomized_benchmarking.py
+++ b/forest/benchmarking/tests/test_randomized_benchmarking.py
@@ -35,7 +35,7 @@ def test_1q_general_pauli_noise(qvm, benchmarker):
     depths = [depth for depth in depths for _ in range(num_sequences_per_depth)]
     qubits = (0, )
 
-    sequences = generate_rb_experiment_sequences(benchmarker, qubits, depths)
+    sequences = generate_rb_experiment_sequences(benchmarker, qubits, depths, random_seed=1)
     add_noise_to_sequences(sequences, qubits)
 
     expts = group_sequences_into_parallel_experiments([sequences], [qubits])
@@ -66,7 +66,7 @@ def test_2q_general_pauli_noise(qvm, benchmarker):
     depths = [depth for depth in depths for _ in range(num_sequences_per_depth)]
     qubits = (0, 1)
 
-    sequences = generate_rb_experiment_sequences(benchmarker, qubits, depths)
+    sequences = generate_rb_experiment_sequences(benchmarker, qubits, depths, random_seed=1)
     add_noise_to_sequences(sequences, qubits)
 
     expts = group_sequences_into_parallel_experiments([sequences], [qubits])
@@ -190,7 +190,8 @@ def test_unitarity(qvm, benchmarker):
     kraus_ops = depolarizing_noise(len(qubits), expected_p)
 
     sequences = generate_rb_experiment_sequences(benchmarker, qubits, depths,
-                                                 use_self_inv_seqs=False)
+                                                 use_self_inv_seqs=False,
+                                                 random_seed=1)
     add_noise_to_sequences(sequences, qubits)
 
     expts = group_sequences_into_parallel_experiments([sequences], [qubits], is_unitarity_expt=True)


### PR DESCRIPTION
Description
-----------

Set random seed in `test_2q_general_pauli_noise`  when generating rb experiment sequences.

Checklist
---------

- [x] The above description motivates these changes.
- [x] There is a unit test that covers these changes.
- [x] The code respects the API separation discussed in .github/CONTRIBUTING.md.
- [x] Relevant references and equations are cited using our standard reference style.
- [x] All new and existing tests pass locally and on Semaphore.
- [x] Parameters have type hints with [PEP 484 syntax](https://www.python.org/dev/peps/pep-0484/).
- [x] Functions and classes have useful sphinx-style docstrings.
- [x] (New Feature) The docs and example notebooks have been updated accordingly.
- [x] (Bugfix) The associated issue is referenced above using
      [auto-close keywords](https://help.github.com/en/articles/closing-issues-using-keywords).
- [x] The changelog (`docs/source/changes.rst`) has a description of this change.
