### PR TITLE
Fix #242 trace_distance to use nuclear norm

### DIFF
--- a/forest/benchmarking/distance_measures.py
+++ b/forest/benchmarking/distance_measures.py
@@ -111,7 +111,7 @@ def trace_distance(rho: np.ndarray, sigma: np.ndarray) -> float:
     :param sigma: Is a dim by dim positive matrix with unit trace.
     :return: Trace distance which is a scalar.
     """
-    return (0.5) * np.linalg.norm(rho - sigma, 1)
+    return (0.5) * np.linalg.norm(rho - sigma, 'nuc')
 
 
 def bures_distance(rho: np.ndarray, sigma: np.ndarray) -> float:


### PR DESCRIPTION
Fix #242 by replacing call to `numpy.linalg.norm(x,1)` with `numpy.linalg.norm(x,'nuc')`